### PR TITLE
Add basic token middleware

### DIFF
--- a/api/controllers/token.ts
+++ b/api/controllers/token.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+import { isValidObjectId } from 'mongoose';
+
+import { TokenModel } from "../models/token";
+
+export default async function token(req: Request, res: Response, next: NextFunction) {
+  const tokenId = req.header('Authorization');
+  if (!isValidObjectId(tokenId)) {
+    return res.status(400).json({
+      error: 'invalid authorization token'
+    });
+  }
+  const token = await TokenModel.findById(tokenId).exec();
+  if (!token) {
+    return res.status(500).json({
+      error: 'authorization token not found'
+    });
+  }
+  if (!token.active) {
+    return res.status(400).json({
+      error: 'authorization token is not active'
+    });
+  }
+  next();
+}

--- a/api/models/token.ts
+++ b/api/models/token.ts
@@ -1,0 +1,18 @@
+import { Schema, connection } from 'mongoose';
+
+export interface Token {
+  creator: string,
+  user: string,
+  active: boolean
+}
+
+const TokenSchema = new Schema<Token>({
+  creator: { type: String, required: true },
+  user: { type: String, required: true },
+  active: { type: Boolean, required: true }
+}, {
+  timestamps: true
+});
+
+const tokenDB = connection.useDb('tokenDB');
+export const TokenModel = tokenDB.model<Token>('token', TokenSchema);

--- a/api/server.ts
+++ b/api/server.ts
@@ -4,11 +4,14 @@ import mongoose from 'mongoose';
 
 import course from './routes/course';
 import degree from './routes/degree';
+import token from './controllers/token';
 
 dotenv.config();
 
 mongoose.connect(process.env.MONGODB_URI).then(() => {
   const app = express();
+
+  app.use(token);
 
   app.use('/course', course);
   app.use('/degree', degree);


### PR DESCRIPTION
## Overview
Resolves #28 

The changes in this pull request add basic token functionality to add more control and security to the API. Token creation and customization are currently limited to being made directly in MongoDB.

## What Changed
The changes are:
1. Add middleware that checks for an Authorization HTTP header and compares it to tokens' objectId
2. Add tokenDB to the MongoDB development cluster 
3. Add schema for an API token

## Future Steps
Future implementations related to this:
1. Implement API Token Rate Limiting #30 
2. Implement API Token Permissions and Authorization #29 