### PR TITLE
Add `core_flags` field

### DIFF
--- a/docs/schemas/section.md
+++ b/docs/schemas/section.md
@@ -93,6 +93,14 @@ Section = {
 > 
 > An array of the locations and times that this section meets.
 
+> `.core_flags`
+> 
+> **Type**: Array<string>
+> 
+> An array of core requirement codes this section fulfills. 
+>
+> **Example**: ["020", "050", ...]
+
 > `.syllabus_uri`
 > 
 > **Type**: string


### PR DESCRIPTION
The current schema has no field for specifying core requirements that a section meets, which was one of the requirements of the schema. This should fix that.