### PR TITLE
Add `DegreeSubtype` and `school` field

### DIFF
--- a/docs/schemas/degree.md
+++ b/docs/schemas/degree.md
@@ -5,11 +5,12 @@ A `Degree` represents either a major, minor, or concentration received from The 
 
 ## Object Representation
 ```ts
-DegreeSubtype = "major" | "minor" | "concentration"
+DegreeSubtype = "major" | "minor" | "concentration" | "prescribed double major"
 
 Degree = {
     "_id": ObjectId,
     "subtype": DegreeSubtype,
+    "school": string,
     "name": string,
     "year": string,
     "abbreviation": string,
@@ -34,6 +35,14 @@ Degree = {
 > The subtype of degree that this object represents.
 >
 > **Example**: Major
+
+> `.school`
+>
+> **Type**: string
+>
+> The school that the `degree` belongs to.
+>
+> **Example**: School of Natural Sciences and Mathematics
 
 > `.name`
 >


### PR DESCRIPTION
I noticed looking at all degrees at UT Dallas that there are many prescribed double majors (i.e. Bachelor of Science in Healthcare Management and Molecular Biology (Double Major)) with individualized degree plans. It is necessary to have a separate degree subtype to represent these.

I also noticed that all the degrees are nicely sorted by school and it would be easy to scrape them; Hence, the `school` field.