### PR TITLE
Properly list `core_flags` field in docs

### DIFF
--- a/docs/schemas/section.md
+++ b/docs/schemas/section.md
@@ -16,6 +16,7 @@ Section = {
     "internal_class_number": string,
     "instruction_mode": string,
     "meetings": Array<Meeting>,
+    "core_flags": Array<string>,
     "syllabus_uri": string,
     "grade_distribution": Array<number>,
     "attributes": Object,


### PR DESCRIPTION
Accidentally forgot to add `core_flags` field to the top of the section doc to go with #74