### PR TITLE
Add Exam Data

### DIFF
--- a/scraper/data/Exams.json
+++ b/scraper/data/Exams.json
@@ -1,13 +1,17 @@
 [
 	{
-		"_id": "623f8ef656965e1884291c17",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c17"
+		},
 		"type": "AP",
 		"name": "History of Art",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c17",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c17"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -22,7 +26,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c17",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c17"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -36,7 +42,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c17",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c17"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -50,14 +58,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c18",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c18"
+		},
 		"type": "AP",
 		"name": "Studio Art: 2-D Design",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c18",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c18"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -72,7 +84,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c18",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c18"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -86,7 +100,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c18",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c18"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -100,14 +116,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c19",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c19"
+		},
 		"type": "AP",
 		"name": "Studio Art: Drawing",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c19",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c19"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -122,7 +142,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c19",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c19"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -136,7 +158,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c19",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c19"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -150,14 +174,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c1a",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c1a"
+		},
 		"type": "AP",
 		"name": "General Biology",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1a"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -172,7 +200,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1a"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -195,7 +225,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1a"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -221,14 +253,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c1b",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c1b"
+		},
 		"type": "AP",
 		"name": "General Chemistry",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1b"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -243,7 +279,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1b"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -260,7 +298,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1b"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -283,14 +323,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c1c",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c1c"
+		},
 		"type": "AP",
 		"name": "Chinese Language & Culture",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1c"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -304,7 +348,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1c"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -321,7 +367,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1c"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -341,14 +389,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c1d",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c1d"
+		},
 		"type": "AP",
 		"name": "Computer Science A",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1d"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -363,7 +415,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1d"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -380,7 +434,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1d"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -397,14 +453,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c1e",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c1e"
+		},
 		"type": "AP",
 		"name": "Macroeconomics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1e"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -419,7 +479,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1e"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -433,7 +495,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1e"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -447,14 +511,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c1f",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c1f"
+		},
 		"type": "AP",
 		"name": "Microeconomics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1f"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -469,7 +537,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1f"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -483,7 +553,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c1f"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -497,14 +569,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c20",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c20"
+		},
 		"type": "AP",
 		"name": "English Language and Composition",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c20",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c20"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -519,7 +595,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c20",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c20"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -533,7 +611,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c20",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c20"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -547,14 +627,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c21",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c21"
+		},
 		"type": "AP",
 		"name": "English Literature and Composition",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c21",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c21"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -569,7 +653,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c21",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c21"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -583,7 +669,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c21",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c21"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -597,14 +685,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c22",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c22"
+		},
 		"type": "AP",
 		"name": "French Language",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c22",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c22"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -618,7 +710,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c22",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c22"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -635,7 +729,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c22",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c22"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -655,14 +751,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c23",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c23"
+		},
 		"type": "AP",
 		"name": "Human Geography",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c23",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c23"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -676,7 +776,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c23",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c23"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -690,7 +792,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c23",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c23"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -704,14 +808,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c24",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c24"
+		},
 		"type": "AP",
 		"name": "German Language",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c24",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c24"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -725,7 +833,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c24",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c24"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -742,7 +852,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c24",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c24"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -762,14 +874,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c25",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c25"
+		},
 		"type": "AP",
 		"name": "Comp Government and Politics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c25",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c25"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -784,7 +900,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c25",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c25"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -799,7 +917,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c25",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c25"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -814,14 +934,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c26",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c26"
+		},
 		"type": "AP",
 		"name": "US Government and Politics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c26",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c26"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -835,7 +959,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c26",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c26"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -849,7 +975,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c26",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c26"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -863,14 +991,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c27",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c27"
+		},
 		"type": "AP",
 		"name": "United States History",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c27",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c27"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -884,7 +1016,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c27",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c27"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -901,7 +1035,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c27",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c27"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -918,14 +1054,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c28",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c28"
+		},
 		"type": "AP",
 		"name": "Japanese Language & Culture",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c28",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c28"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -939,7 +1079,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c28",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c28"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -956,7 +1098,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c28",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c28"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -976,7 +1120,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c29",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c29"
+		},
 		"type": "AP",
 		"name": "Calculus AB",
 		"yields": [
@@ -988,7 +1134,9 @@
 					"options": [
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c29",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c29"
+							},
 							"minimumscore": 3
 						},
 						{
@@ -1014,7 +1162,9 @@
 					"options": [
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c29",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c29"
+							},
 							"minimumscore": 4
 						},
 						{
@@ -1051,7 +1201,9 @@
 					"options": [
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c29",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c29"
+							},
 							"minimumscore": 5
 						},
 						{
@@ -1083,7 +1235,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c2a",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c2a"
+		},
 		"type": "AP",
 		"name": "Calculus BC",
 		"yields": [
@@ -1095,7 +1249,9 @@
 					"options": [
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c2a",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c2a"
+							},
 							"minimumscore": 3
 						},
 						{
@@ -1137,7 +1293,9 @@
 					"options": [
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c2a",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c2a"
+							},
 							"minimumscore": 4
 						},
 						{
@@ -1182,7 +1340,9 @@
 					"options": [
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c2a",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c2a"
+							},
 							"minimumscore": 5
 						},
 						{
@@ -1222,14 +1382,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c2b",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c2b"
+		},
 		"type": "AP",
 		"name": "Music Theory",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2b"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1243,7 +1407,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2b"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1257,7 +1423,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2b"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1271,14 +1439,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c2c",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c2c"
+		},
 		"type": "AP",
 		"name": "Physics B (non-calculus)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2c"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1293,7 +1465,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2c"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1311,7 +1485,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2c"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1329,14 +1505,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c2d",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c2d"
+		},
 		"type": "AP",
 		"name": "Physics 1",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2d"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1351,7 +1531,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2d"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1369,7 +1551,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2d"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1387,14 +1571,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c2e",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c2e"
+		},
 		"type": "AP",
 		"name": "Physics 2",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2e"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1409,7 +1597,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2e"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1427,7 +1617,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2e"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1445,14 +1637,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c2f",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c2f"
+		},
 		"type": "AP",
 		"name": "Physics C: Mechanics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2f"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1467,7 +1663,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2f"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1484,7 +1682,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c2f"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1501,14 +1701,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c30",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c30"
+		},
 		"type": "AP",
 		"name": "Physics C: Electrical and Magnetic",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c30",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c30"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1559,7 +1763,9 @@
 						},
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c30",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c30"
+							},
 							"minimumscore": 4
 						}
 					]
@@ -1620,7 +1826,9 @@
 						},
 						{
 							"type": "exam",
-							"examReference": "623f8ef656965e1884291c30",
+							"examReference": {
+								"$oid": "623f8ef656965e1884291c30"
+							},
 							"minimumscore": 5
 						}
 					]
@@ -1645,14 +1853,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c31",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c31"
+		},
 		"type": "AP",
 		"name": "General Psychology",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c31",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c31"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1667,7 +1879,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c31",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c31"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1681,7 +1895,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c31",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c31"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1695,14 +1911,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c32",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c32"
+		},
 		"type": "AP",
 		"name": "Spanish Language & Culture",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c32",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c32"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1719,7 +1939,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c32",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c32"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1739,7 +1961,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c32",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c32"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1762,14 +1986,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c33",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c33"
+		},
 		"type": "AP",
 		"name": "Spanish Literature & Culture",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c33",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c33"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1789,7 +2017,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c33",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c33"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1812,7 +2042,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c33",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c33"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1835,14 +2067,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c34",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c34"
+		},
 		"type": "AP",
 		"name": "Statistics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c34",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c34"
+					},
 					"minimumscore": 3
 				},
 				"outcome": [
@@ -1857,7 +2093,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c34",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c34"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -1871,7 +2109,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c34",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c34"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -1885,14 +2125,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c35",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c35"
+		},
 		"type": "CLEP",
 		"name": "College French Level 1 (2 semesters)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c35",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c35"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -1909,14 +2153,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c36",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c36"
+		},
 		"type": "CLEP",
 		"name": "College Level French Level 2 (4 semesters)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c36",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c36"
+					},
 					"minimumscore": 58
 				},
 				"outcome": [
@@ -1939,14 +2187,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c37",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c37"
+		},
 		"type": "CLEP",
 		"name": "College German Level 1 (2 semesters)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c37",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c37"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -1963,14 +2215,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c38",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c38"
+		},
 		"type": "CLEP",
 		"name": "College Level German Level 2 (4 semesters)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c38",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c38"
+					},
 					"minimumscore": 58
 				},
 				"outcome": [
@@ -1993,14 +2249,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c39",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c39"
+		},
 		"type": "CLEP",
 		"name": "College Spanish Level 1 (2 semesters)*",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c39",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c39"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2017,14 +2277,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c3a",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c3a"
+		},
 		"type": "CLEP",
 		"name": "College Spanish Level 2 (3 semesters)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c3a"
+					},
 					"minimumscore": 60
 				},
 				"outcome": [
@@ -2044,14 +2308,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c3b",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c3b"
+		},
 		"type": "CLEP",
 		"name": "College Spanish with Writing (4 semesters)",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c3b"
+					},
 					"minimumscore": 65
 				},
 				"outcome": [
@@ -2074,14 +2342,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c3c",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c3c"
+		},
 		"type": "CLEP",
 		"name": "American Government",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c3c"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2095,14 +2367,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c3d",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c3d"
+		},
 		"type": "CLEP",
 		"name": "American History I: Early Colonization to 1877",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c3d"
+					},
 					"minimumscore": 60
 				},
 				"outcome": [
@@ -2116,14 +2392,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c3e",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c3e"
+		},
 		"type": "CLEP",
 		"name": "American History II: 1865 to Present",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c3e"
+					},
 					"minimumscore": 60
 				},
 				"outcome": [
@@ -2137,14 +2417,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c3f",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c3f"
+		},
 		"type": "CLEP",
 		"name": "Human Growth and Development",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c3f"
+					},
 					"minimumscore": 57
 				},
 				"outcome": [
@@ -2158,14 +2442,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c40",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c40"
+		},
 		"type": "CLEP",
 		"name": "Introduction to Educational Psychology",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c40",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c40"
+					},
 					"minimumscore": 57
 				},
 				"outcome": [
@@ -2180,14 +2468,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c41",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c41"
+		},
 		"type": "CLEP",
 		"name": "Introductory Macroeconomics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c41",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c41"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2201,14 +2493,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c42",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c42"
+		},
 		"type": "CLEP",
 		"name": "Introductory Microeconomics",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c42",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c42"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2222,14 +2518,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c43",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c43"
+		},
 		"type": "CLEP",
 		"name": "Introductory Psychology",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c43",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c43"
+					},
 					"minimumscore": 57
 				},
 				"outcome": [
@@ -2243,14 +2543,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c44",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c44"
+		},
 		"type": "CLEP",
 		"name": "Western Civilization I: Ancient Near East to 1648",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c44",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c44"
+					},
 					"minimumscore": 60
 				},
 				"outcome": [
@@ -2264,14 +2568,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c45",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c45"
+		},
 		"type": "CLEP",
 		"name": "Western Civilization II: 1648 to Present",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c45",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c45"
+					},
 					"minimumscore": 60
 				},
 				"outcome": [
@@ -2285,14 +2593,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c46",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c46"
+		},
 		"type": "CLEP",
 		"name": "Calculus with Elementary Functions",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c46",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c46"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2309,7 +2621,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c46",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c46"
+					},
 					"minimumscore": 61
 				},
 				"outcome": [
@@ -2326,14 +2640,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c47",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c47"
+		},
 		"type": "CLEP",
 		"name": "College Algebra",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c47",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c47"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2347,14 +2665,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c48",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c48"
+		},
 		"type": "CLEP",
 		"name": "General Biology",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c48",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c48"
+					},
 					"minimumscore": 56
 				},
 				"outcome": [
@@ -2377,14 +2699,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c49",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c49"
+		},
 		"type": "CLEP",
 		"name": "General Chemistry",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c49",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c49"
+					},
 					"minimumscore": 60
 				},
 				"outcome": [
@@ -2401,7 +2727,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c49",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c49"
+					},
 					"minimumscore": 70
 				},
 				"outcome": [
@@ -2424,14 +2752,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c4a",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c4a"
+		},
 		"type": "CLEP",
 		"name": "Pre-calculus",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4a"
+					},
 					"minimumscore": 58
 				},
 				"outcome": [
@@ -2445,14 +2777,18 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c4b",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c4b"
+		},
 		"type": "CLEP",
 		"name": "Information Systems and Computer Applications",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4b"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -2467,7 +2803,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c4c",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c4c"
+		},
 		"type": "IB",
 		"name": "Biology",
 		"level": "Standard",
@@ -2475,7 +2813,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4c"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2490,7 +2830,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4c"
+					},
 					"minimumscore": 7
 				},
 				"outcome": [
@@ -2513,7 +2855,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c4d",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c4d"
+		},
 		"type": "IB",
 		"name": "Biology",
 		"level": "Higher",
@@ -2521,7 +2865,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4d"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2536,7 +2882,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4d"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -2559,7 +2907,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c4e",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c4e"
+		},
 		"type": "IB",
 		"name": "Chemistry",
 		"level": "Standard",
@@ -2567,7 +2917,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4e"
+					},
 					"minimumscore": 7
 				},
 				"outcome": [
@@ -2590,7 +2942,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c4f",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c4f"
+		},
 		"type": "IB",
 		"name": "Chemistry",
 		"level": "Higher",
@@ -2598,7 +2952,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c4f"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -2621,7 +2977,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c50",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c50"
+		},
 		"type": "IB",
 		"name": "Computer Science",
 		"level": "Higher",
@@ -2629,7 +2987,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c50",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c50"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -2646,7 +3006,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c51",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c51"
+		},
 		"type": "IB",
 		"name": "Computer Science",
 		"level": "Standard",
@@ -2654,7 +3016,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c51",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c51"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -2671,7 +3035,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c52",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c52"
+		},
 		"type": "IB",
 		"name": "Economics",
 		"level": "Standard",
@@ -2679,7 +3045,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c52",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c52"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2693,7 +3061,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c53",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c53"
+		},
 		"type": "IB",
 		"name": "Economics",
 		"level": "Higher",
@@ -2701,7 +3071,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c53",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c53"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2718,7 +3090,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c54",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c54"
+		},
 		"type": "IB",
 		"name": "Language A: Literature",
 		"level": "Standard",
@@ -2726,7 +3100,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c54",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c54"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2740,7 +3116,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c54",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c54"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2757,7 +3135,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c55",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c55"
+		},
 		"type": "IB",
 		"name": "Language A: Literature",
 		"level": "Higher",
@@ -2765,7 +3145,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c55",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c55"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2779,7 +3161,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c55",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c55"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2796,7 +3180,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c56",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c56"
+		},
 		"type": "IB",
 		"name": "Language A: Language and Literature",
 		"level": "Standard",
@@ -2804,7 +3190,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c56",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c56"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2818,7 +3206,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c56",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c56"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2835,7 +3225,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c57",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c57"
+		},
 		"type": "IB",
 		"name": "Language A: Language and Literature",
 		"level": "Higher",
@@ -2843,7 +3235,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c57",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c57"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2857,7 +3251,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c57",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c57"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2874,7 +3270,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c58",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c58"
+		},
 		"type": "IB",
 		"name": "Environmental Systems and Societies",
 		"level": "Standard",
@@ -2882,7 +3280,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c58",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c58"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2897,7 +3297,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c58",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c58"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -2911,7 +3313,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c59",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c59"
+		},
 		"type": "IB",
 		"name": "Geography",
 		"level": "Higher",
@@ -2919,7 +3323,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c59",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c59"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2934,7 +3340,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c59",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c59"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -2948,7 +3356,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c5a",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c5a"
+		},
 		"type": "IB",
 		"name": "History (Any Regional Area)",
 		"level": "Higher",
@@ -2956,7 +3366,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c5a"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -2971,7 +3383,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c5b",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c5b"
+		},
 		"type": "IB",
 		"name": "Any B languange offered by UTD",
 		"level": "Standard",
@@ -2979,7 +3393,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c5b"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -2994,7 +3410,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c5c",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c5c"
+		},
 		"type": "IB",
 		"name": "Arabic B",
 		"level": "Higher",
@@ -3002,7 +3420,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c5c"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3019,7 +3439,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c5d",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c5d"
+		},
 		"type": "IB",
 		"name": "Chinese B",
 		"level": "Higher",
@@ -3027,7 +3449,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c5d"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3044,7 +3468,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c5e",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c5e"
+		},
 		"type": "IB",
 		"name": "Frence B",
 		"level": "Higher",
@@ -3052,7 +3478,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c5e"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3069,7 +3497,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c5f",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c5f"
+		},
 		"type": "IB",
 		"name": "Spanish (A or B)",
 		"level": "Standard",
@@ -3077,7 +3507,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c5f"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3097,7 +3529,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c60",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c60"
+		},
 		"type": "IB",
 		"name": "Spanish (A or B)",
 		"level": "Higher",
@@ -3105,7 +3539,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c60",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c60"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3128,7 +3564,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c61",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c61"
+		},
 		"type": "IB",
 		"name": "Mathematics",
 		"level": "Standard",
@@ -3136,7 +3574,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c61",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c61"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3150,7 +3590,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c61",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c61"
+					},
 					"minimumscore": 7
 				},
 				"outcome": [
@@ -3167,7 +3609,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c62",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c62"
+		},
 		"type": "IB",
 		"name": "Mathematics",
 		"level": "Higher",
@@ -3175,7 +3619,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c62",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c62"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3189,7 +3635,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c62",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c62"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3209,7 +3657,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c63",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c63"
+		},
 		"type": "IB",
 		"name": "Mathematics Analysis and Approaches",
 		"level": "Higher",
@@ -3217,7 +3667,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c63",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c63"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3236,7 +3688,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c63",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c63"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3250,7 +3704,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c63",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c63"
+					},
 					"minimumscore": 7
 				},
 				"outcome": [
@@ -3264,7 +3720,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c64",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c64"
+		},
 		"type": "IB",
 		"name": "Mathematics Analysis and Approaches",
 		"level": "Standard",
@@ -3272,7 +3730,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c64",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c64"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3286,7 +3746,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c64",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c64"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3300,7 +3762,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c65",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c65"
+		},
 		"type": "IB",
 		"name": "Mathematics Applications and Interpretations",
 		"level": "Higher",
@@ -3308,7 +3772,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c65",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c65"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3327,7 +3793,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c66",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c66"
+		},
 		"type": "IB",
 		"name": "Mathematics Applications and Interpretations",
 		"level": "Standard",
@@ -3335,7 +3803,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c66",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c66"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3349,7 +3819,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c67",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c67"
+		},
 		"type": "IB",
 		"name": "Further Mathematics",
 		"level": "Higher",
@@ -3357,7 +3829,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c67",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c67"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3380,7 +3854,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c67",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c67"
+					},
 					"minimumscore": 7
 				},
 				"outcome": [
@@ -3406,7 +3882,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c68",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c68"
+		},
 		"type": "IB",
 		"name": "Music",
 		"level": "Standard",
@@ -3414,7 +3892,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c68",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c68"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3428,7 +3908,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c69",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c69"
+		},
 		"type": "IB",
 		"name": "Music",
 		"level": "Higher",
@@ -3436,7 +3918,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c69",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c69"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3450,7 +3934,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c6a",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c6a"
+		},
 		"type": "IB",
 		"name": "Philosophy",
 		"level": "Standard",
@@ -3458,7 +3944,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6a",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c6a"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3472,7 +3960,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c6b",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c6b"
+		},
 		"type": "IB",
 		"name": "Philosophy",
 		"level": "Higher",
@@ -3480,7 +3970,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6b",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c6b"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3494,7 +3986,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c6c",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c6c"
+		},
 		"type": "IB",
 		"name": "Physics",
 		"level": "Standard",
@@ -3502,7 +3996,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6c",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c6c"
+					},
 					"minimumscore": 7
 				},
 				"outcome": [
@@ -3525,7 +4021,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c6d",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c6d"
+		},
 		"type": "IB",
 		"name": "Physics",
 		"level": "Higher",
@@ -3533,7 +4031,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6d",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c6d"
+					},
 					"minimumscore": 6
 				},
 				"outcome": [
@@ -3556,7 +4056,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c6e",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c6e"
+		},
 		"type": "IB",
 		"name": "Psychology",
 		"level": "Higher",
@@ -3564,7 +4066,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6e",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c6e"
+					},
 					"minimumscore": 5
 				},
 				"outcome": [
@@ -3578,7 +4082,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c6f",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c6f"
+		},
 		"type": "IB",
 		"name": "Theatre",
 		"level": "Standard",
@@ -3586,7 +4092,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6f",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c6f"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3600,7 +4108,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c70",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c70"
+		},
 		"type": "IB",
 		"name": "Theatre",
 		"level": "Higher",
@@ -3608,7 +4118,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c70",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c70"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3622,7 +4134,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c71",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c71"
+		},
 		"type": "IB",
 		"name": "Visual Arts",
 		"level": "Standard",
@@ -3630,7 +4144,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c71",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c71"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3644,7 +4160,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c72",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c72"
+		},
 		"type": "IB",
 		"name": "Visual Arts",
 		"level": "Higher",
@@ -3652,7 +4170,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c72",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c72"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3666,7 +4186,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c73",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c73"
+		},
 		"type": "IB",
 		"name": "Film",
 		"level": "Standard",
@@ -3674,7 +4196,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c73",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c73"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3688,7 +4212,9 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c74",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c74"
+		},
 		"type": "IB",
 		"name": "Film",
 		"level": "Higher",
@@ -3696,7 +4222,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c74",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c74"
+					},
 					"minimumscore": 4
 				},
 				"outcome": [
@@ -3710,13 +4238,17 @@
 		]
 	},
 	{
-		"_id": "623f8ef656965e1884291c75",
+		"_id": {
+			"$oid": "623f8ef656965e1884291c75"
+		},
 		"type": "ALEKS",
 		"yields": [
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c75"
+					},
 					"minimumscore": 35
 				},
 				"outcome": [
@@ -3730,7 +4262,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c75"
+					},
 					"minimumscore": 50
 				},
 				"outcome": [
@@ -3747,7 +4281,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c75"
+					},
 					"minimumscore": 70
 				},
 				"outcome": [
@@ -3767,7 +4303,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c75"
+					},
 					"minimumscore": 80
 				},
 				"outcome": [
@@ -3784,7 +4322,9 @@
 			{
 				"requirement": {
 					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
+					"examReference": {
+						"$oid": "623f8ef656965e1884291c75"
+					},
 					"minimumscore": 85
 				},
 				"outcome": [

--- a/scraper/data/Exams.json
+++ b/scraper/data/Exams.json
@@ -28,8 +28,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "AHST",
-							"number": 2331
+							"$oid": "62410d50e27d0c74c4093e65"
 						}
 					]
 				]
@@ -43,8 +42,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "AHST",
-							"number": 2331
+							"$oid": "62410d50e27d0c74c4093e65"
 						}
 					]
 				]
@@ -80,8 +78,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "ARTS",
-							"number": 2380
+							"$oid": "624110bee27d0c74c4093eac"
 						}
 					]
 				]
@@ -95,8 +92,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "ARTS",
-							"number": 2380
+							"$oid": "624110bee27d0c74c4093eac"
 						}
 					]
 				]
@@ -131,7 +127,9 @@
 				},
 				"outcome": [
 					[
-						"623e0e7981e2c241bf43902e"
+						{
+							"$oid": "62411007e27d0c74c4093e9b"
+						}
 					]
 				]
 			},
@@ -143,7 +141,9 @@
 				},
 				"outcome": [
 					[
-						"623e0e7981e2c241bf43902e"
+						{
+							"$oid": "62411007e27d0c74c4093e9b"
+						}
 					]
 				]
 			}
@@ -177,10 +177,18 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad",
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa"
+						{
+							"$oid": "624122bde27d0c74c40940a3"
+						},
+						{
+							"$oid": "624122b5e27d0c74c409408b"
+						},
+						{
+							"$oid": "624122bce27d0c74c409409f"
+						},
+						{
+							"$oid": "624122b0e27d0c74c409407c"
+						}
 					]
 				]
 			},
@@ -192,11 +200,21 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad",
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f5381e2c241bf4390b0"
+						{
+							"$oid": "624122bde27d0c74c40940a3"
+						},
+						{
+							"$oid": "624122b5e27d0c74c409408b"
+						},
+						{
+							"$oid": "624122bce27d0c74c409409f"
+						},
+						{
+							"$oid": "624122b0e27d0c74c409407c"
+						},
+						{
+							"$oid": "624122b7e27d0c74c4094092"
+						}
 					]
 				]
 			}
@@ -230,8 +248,12 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197"
+						{
+							"$oid": "624137f6e27d0c74c40943c2"
+						},
+						{
+							"$oid": "624135dae27d0c74c4094385"
+						}
 					]
 				]
 			},
@@ -243,10 +265,18 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"$oid": "624137f6e27d0c74c40943c2"
+						},
+						{
+							"$oid": "624135dae27d0c74c4094385"
+						},
+						{
+							"$oid": "624137fce27d0c74c40943cc"
+						},
+						{
+							"$oid": "624137f2e27d0c74c40943b5"
+						}
 					]
 				]
 			}
@@ -266,8 +296,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "CHIN",
-							"number": 1311
+							"$oid": "6241389ae27d0c74c409442d"
 						}
 					]
 				]
@@ -281,12 +310,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "CHIN",
-							"number": 1311
+							"$oid": "6241389ae27d0c74c409442d"
 						},
 						{
-							"prefix": "CHIN",
-							"number": 1312
+							"$oid": "6241389fe27d0c74c4094431"
 						}
 					]
 				]
@@ -300,16 +327,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "CHIN",
-							"number": 1311
+							"$oid": "6241389ae27d0c74c409442d"
 						},
 						{
-							"prefix": "CHIN",
-							"number": 1312
+							"$oid": "6241389fe27d0c74c4094431"
 						},
 						{
-							"prefix": "CHIN",
-							"number": 2311
+							"$oid": "624138a2e27d0c74c4094433"
 						}
 					]
 				]
@@ -344,8 +368,12 @@
 				},
 				"outcome": [
 					[
-						"623e1d098ed6651333148186",
-						"623e1d098ed6651333148188"
+						{
+							"$oid": "62414c43e27d0c74c4094562"
+						},
+						{
+							"$oid": "62414c4be27d0c74c4094578"
+						}
 					]
 				]
 			},
@@ -357,8 +385,12 @@
 				},
 				"outcome": [
 					[
-						"623e1d098ed6651333148186",
-						"623e1d098ed6651333148188"
+						{
+							"$oid": "62414c43e27d0c74c4094562"
+						},
+						{
+							"$oid": "62414c4be27d0c74c4094578"
+						}
 					]
 				]
 			}
@@ -392,7 +424,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"$oid": "624155217a5c14bdce6ae607"
+						}
 					]
 				]
 			},
@@ -404,7 +438,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"$oid": "624155217a5c14bdce6ae607"
+						}
 					]
 				]
 			}
@@ -438,7 +474,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3e8ed66513331481de"
+						{
+							"$oid": "624155237a5c14bdce6ae60d"
+						}
 					]
 				]
 			},
@@ -450,7 +488,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3e8ed66513331481de"
+						{
+							"$oid": "624155237a5c14bdce6ae60d"
+						}
 					]
 				]
 			}
@@ -484,7 +524,9 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						}
 					]
 				]
 			},
@@ -496,7 +538,9 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						}
 					]
 				]
 			}
@@ -530,7 +574,9 @@
 				},
 				"outcome": [
 					[
-						"623e38a744e0512c7a91dfaa"
+						{
+							"$oid": "62417f837a5c14bdce6aeb91"
+						}
 					]
 				]
 			},
@@ -542,7 +588,9 @@
 				},
 				"outcome": [
 					[
-						"623e38a744e0512c7a91dfaa"
+						{
+							"$oid": "62417f837a5c14bdce6aeb91"
+						}
 					]
 				]
 			}
@@ -562,8 +610,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "FREN",
-							"number": 1311
+							"$oid": "624167907a5c14bdce6ae8ec"
 						}
 					]
 				]
@@ -577,12 +624,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "FREN",
-							"number": 1311
+							"$oid": "624167907a5c14bdce6ae8ec"
 						},
 						{
-							"prefix": "FREN",
-							"number": 1312
+							"$oid": "62415ed70cef69f0ebc9c8aa"
 						}
 					]
 				]
@@ -596,16 +641,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "FREN",
-							"number": 1311
+							"$oid": "624167907a5c14bdce6ae8ec"
 						},
 						{
-							"prefix": "FREN",
-							"number": 1312
+							"$oid": "62415ed70cef69f0ebc9c8aa"
 						},
 						{
-							"prefix": "FREN",
-							"number": 2311
+							"$oid": "624167947a5c14bdce6ae8ee"
 						}
 					]
 				]
@@ -626,8 +668,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GEOG",
-							"number": 2303
+							"$oid": "624168507a5c14bdce6ae8f2"
 						}
 					]
 				]
@@ -641,8 +682,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GEOG",
-							"number": 2303
+							"$oid": "624168507a5c14bdce6ae8f2"
 						}
 					]
 				]
@@ -656,8 +696,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GEOG",
-							"number": 2303
+							"$oid": "624168507a5c14bdce6ae8f2"
 						}
 					]
 				]
@@ -678,8 +717,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GERM",
-							"number": 1311
+							"$oid": "62416a617a5c14bdce6ae944"
 						}
 					]
 				]
@@ -693,12 +731,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GERM",
-							"number": 1311
+							"$oid": "62416a617a5c14bdce6ae944"
 						},
 						{
-							"prefix": "GERM",
-							"number": 1312
+							"$oid": "62415ff27901d4c256b81510"
 						}
 					]
 				]
@@ -712,16 +748,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GERM",
-							"number": 1311
+							"$oid": "62416a617a5c14bdce6ae944"
 						},
 						{
-							"prefix": "GERM",
-							"number": 1312
+							"$oid": "62415ff27901d4c256b81510"
 						},
 						{
-							"prefix": "GERM",
-							"number": 2311
+							"$oid": "62416a667a5c14bdce6ae947"
 						}
 					]
 				]
@@ -793,7 +826,9 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"$oid": "62416be87a5c14bdce6ae972"
+						}
 					]
 				]
 			},
@@ -805,7 +840,9 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"$oid": "62416be87a5c14bdce6ae972"
+						}
 					]
 				]
 			},
@@ -817,7 +854,9 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"$oid": "62416be87a5c14bdce6ae972"
+						}
 					]
 				]
 			}
@@ -837,8 +876,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "HIST",
-							"number": 1301
+							"$oid": "624170ea7a5c14bdce6ae9e7"
 						}
 					]
 				]
@@ -852,10 +890,11 @@
 				"outcome": [
 					[
 						{
-							"prefix": "HIST",
-							"number": 1301
+							"$oid": "624170ea7a5c14bdce6ae9e7"
 						},
-						"623e382844e0512c7a91df4d"
+						{
+							"$oid": "624170f07a5c14bdce6ae9fb"
+						}
 					]
 				]
 			},
@@ -868,10 +907,11 @@
 				"outcome": [
 					[
 						{
-							"prefix": "HIST",
-							"number": 1301
+							"$oid": "624170ea7a5c14bdce6ae9e7"
 						},
-						"623e382844e0512c7a91df4d"
+						{
+							"$oid": "624170f07a5c14bdce6ae9fb"
+						}
 					]
 				]
 			}
@@ -891,8 +931,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "JAPN",
-							"number": 1311
+							"$oid": "62417b377a5c14bdce6aeb75"
 						}
 					]
 				]
@@ -906,12 +945,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "JAPN",
-							"number": 1311
+							"$oid": "62417b377a5c14bdce6aeb75"
 						},
 						{
-							"prefix": "JAPN",
-							"number": 1312
+							"$oid": "62416faee38ffbda93293305"
 						}
 					]
 				]
@@ -925,16 +962,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "JAPN",
-							"number": 1311
+							"$oid": "62417b377a5c14bdce6aeb75"
 						},
 						{
-							"prefix": "JAPN",
-							"number": 1312
+							"$oid": "62416faee38ffbda93293305"
 						},
 						{
-							"prefix": "JAPN",
-							"number": 2311
+							"$oid": "62417b3d7a5c14bdce6aeb79"
 						}
 					]
 				]
@@ -966,7 +1000,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						}
 					]
 				]
 			},
@@ -990,12 +1026,20 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						}
 					]
 				]
 			},
@@ -1019,12 +1063,20 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						}
 					]
 				]
 			}
@@ -1060,12 +1112,20 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						}
 					]
 				]
 			},
@@ -1089,16 +1149,28 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a823e0a87a87f38b1b1b"
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfba",
-						"623e3a1d44e0512c7a91dfbc"
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						},
+						{
+							"$oid": "6241a538e0a87a87f38b1a88"
+						}
 					],
 					[
-						"623e3a1e44e0512c7a91dfc0",
-						"623e3a5b44e0512c7a91dfc6"
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						},
+						{
+							"$oid": "6241a7c7e0a87a87f38b1aea"
+						}
 					]
 				]
 			},
@@ -1122,16 +1194,28 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a823e0a87a87f38b1b1b"
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfba",
-						"623e3a1d44e0512c7a91dfbc"
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						},
+						{
+							"$oid": "6241a538e0a87a87f38b1a88"
+						}
 					],
 					[
-						"623e3a1e44e0512c7a91dfc0",
-						"623e3a5b44e0512c7a91dfc6"
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						},
+						{
+							"$oid": "6241a7c7e0a87a87f38b1aea"
+						}
 					]
 				]
 			}
@@ -1151,8 +1235,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "MUSI",
-							"number": 2328
+							"$oid": "6241b854e0a87a87f38b1da5"
 						}
 					]
 				]
@@ -1166,8 +1249,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "MUSI",
-							"number": 2328
+							"$oid": "6241b854e0a87a87f38b1da5"
 						}
 					]
 				]
@@ -1181,8 +1263,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "MUSI",
-							"number": 2328
+							"$oid": "6241b854e0a87a87f38b1da5"
 						}
 					]
 				]
@@ -1217,7 +1298,9 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1233,7 +1316,9 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1271,7 +1356,9 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1287,7 +1374,9 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1325,7 +1414,9 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1341,7 +1432,9 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1379,8 +1472,12 @@
 				},
 				"outcome": [
 					[
-						"623e477f44e0512c7a91e0ed",
-						"623e477d44e0512c7a91e0e1"
+						{
+							"$oid": "6241c5cbe0a87a87f38b1f99"
+						},
+						{
+							"$oid": "6241c5b7e0a87a87f38b1f61"
+						}
 					]
 				]
 			},
@@ -1392,8 +1489,12 @@
 				},
 				"outcome": [
 					[
-						"623e477f44e0512c7a91e0ed",
-						"623e477d44e0512c7a91e0e1"
+						{
+							"$oid": "6241c5cbe0a87a87f38b1f99"
+						},
+						{
+							"$oid": "6241c5b7e0a87a87f38b1f61"
+						}
 					]
 				]
 			}
@@ -1465,8 +1566,12 @@
 				},
 				"outcome": [
 					[
-						"623e478044e0512c7a91e0f1",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"$oid": "6241c5cce0a87a87f38b1f9d"
+						},
+						{
+							"$oid": "6241c5c0e0a87a87f38b1f78"
+						}
 					],
 					[
 						{
@@ -1522,8 +1627,12 @@
 				},
 				"outcome": [
 					[
-						"623e478044e0512c7a91e0f1",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"$oid": "6241c5cce0a87a87f38b1f9d"
+						},
+						{
+							"$oid": "6241c5c0e0a87a87f38b1f78"
+						}
 					],
 					[
 						{
@@ -1563,7 +1672,9 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"$oid": "6241c9abe0a87a87f38b204b"
+						}
 					]
 				]
 			},
@@ -1575,7 +1686,9 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"$oid": "6241c9abe0a87a87f38b204b"
+						}
 					]
 				]
 			}
@@ -1595,12 +1708,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						}
 					]
 				]
@@ -1614,16 +1725,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						}
 					]
 				]
@@ -1637,20 +1745,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2312
+							"$oid": "6241d21be0a87a87f38b21b4"
 						}
 					]
 				]
@@ -1671,16 +1775,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						}
 					]
 				]
@@ -1694,20 +1795,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2312
+							"$oid": "6241d21be0a87a87f38b21b4"
 						}
 					]
 				]
@@ -1721,20 +1818,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2312
+							"$oid": "6241d21be0a87a87f38b21b4"
 						}
 					]
 				]
@@ -1769,7 +1862,9 @@
 				},
 				"outcome": [
 					[
-						"623e4acee98ae00fbe8a347c"
+						{
+							"$oid": "6241d385e0a87a87f38b21d9"
+						}
 					]
 				]
 			},
@@ -1781,7 +1876,9 @@
 				},
 				"outcome": [
 					[
-						"623e4acee98ae00fbe8a347c"
+						{
+							"$oid": "6241d385e0a87a87f38b21d9"
+						}
 					]
 				]
 			}
@@ -1801,12 +1898,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "FREN",
-							"number": 1311
+							"$oid": "624167907a5c14bdce6ae8ec"
 						},
 						{
-							"prefix": "FREN",
-							"number": 1312
+							"$oid": "62415ed70cef69f0ebc9c8aa"
 						}
 					]
 				]
@@ -1827,20 +1922,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "FREN",
-							"number": 1311
+							"$oid": "624167907a5c14bdce6ae8ec"
 						},
 						{
-							"prefix": "FREN",
-							"number": 1312
+							"$oid": "62415ed70cef69f0ebc9c8aa"
 						},
 						{
-							"prefix": "FREN",
-							"number": 2311
+							"$oid": "624167947a5c14bdce6ae8ee"
 						},
 						{
-							"prefix": "FREN",
-							"number": 2312
+							"$oid": "62415ed70cef69f0ebc9c8ac"
 						}
 					]
 				]
@@ -1861,12 +1952,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GERM",
-							"number": 1311
+							"$oid": "62416a617a5c14bdce6ae944"
 						},
 						{
-							"prefix": "GERM",
-							"number": 1312
+							"$oid": "62415ff27901d4c256b81510"
 						}
 					]
 				]
@@ -1887,20 +1976,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GERM",
-							"number": 1311
+							"$oid": "62416a617a5c14bdce6ae944"
 						},
 						{
-							"prefix": "GERM",
-							"number": 1312
+							"$oid": "62415ff27901d4c256b81510"
 						},
 						{
-							"prefix": "GERM",
-							"number": 2311
+							"$oid": "62416a667a5c14bdce6ae947"
 						},
 						{
-							"prefix": "GERM",
-							"number": 2312
+							"$oid": "62415ff27901d4c256b81513"
 						}
 					]
 				]
@@ -1921,12 +2006,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						}
 					]
 				]
@@ -1947,16 +2030,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						}
 					]
 				]
@@ -1977,20 +2057,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2312
+							"$oid": "6241d21be0a87a87f38b21b4"
 						}
 					]
 				]
@@ -2010,7 +2086,9 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"$oid": "62416be87a5c14bdce6ae972"
+						}
 					]
 				]
 			}
@@ -2030,8 +2108,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "HIST",
-							"number": 1301
+							"$oid": "624170ea7a5c14bdce6ae9e7"
 						}
 					]
 				]
@@ -2051,7 +2128,9 @@
 				},
 				"outcome": [
 					[
-						"623e382844e0512c7a91df4d"
+						{
+							"$oid": "624170f07a5c14bdce6ae9fb"
+						}
 					]
 				]
 			}
@@ -2071,8 +2150,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "PSY",
-							"number": 2314
+							"$oid": "6241c9ede0a87a87f38b2052"
 						}
 					]
 				]
@@ -2114,7 +2192,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"$oid": "624155217a5c14bdce6ae607"
+						}
 					]
 				]
 			}
@@ -2133,7 +2213,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3e8ed66513331481de"
+						{
+							"$oid": "624155237a5c14bdce6ae60d"
+						}
 					]
 				]
 			}
@@ -2152,7 +2234,9 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"$oid": "6241c9abe0a87a87f38b204b"
+						}
 					]
 				]
 			}
@@ -2172,8 +2256,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "HUMA",
-							"number": 1301
+							"$oid": "624174c97a5c14bdce6aeab4"
 						}
 					]
 				]
@@ -2194,8 +2277,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "HUMA",
-							"number": 1301
+							"$oid": "624174c97a5c14bdce6aeab4"
 						}
 					]
 				]
@@ -2215,8 +2297,12 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						}
 					]
 				]
 			},
@@ -2228,8 +2314,12 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241a823e0a87a87f38b1b1b"
+						}
 					]
 				]
 			}
@@ -2248,7 +2338,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"$oid": "6241a52fe0a87a87f38b1a6d"
+						}
 					]
 				]
 			}
@@ -2267,10 +2359,18 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad"
+						{
+							"$oid": "624122bce27d0c74c409409f"
+						},
+						{
+							"$oid": "624122b0e27d0c74c409407c"
+						},
+						{
+							"$oid": "624122bde27d0c74c40940a3"
+						},
+						{
+							"$oid": "624122b5e27d0c74c409408b"
+						}
 					]
 				]
 			}
@@ -2289,8 +2389,12 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197"
+						{
+							"$oid": "624137f6e27d0c74c40943c2"
+						},
+						{
+							"$oid": "624135dae27d0c74c4094385"
+						}
 					]
 				]
 			},
@@ -2302,10 +2406,18 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"$oid": "624137f6e27d0c74c40943c2"
+						},
+						{
+							"$oid": "624135dae27d0c74c4094385"
+						},
+						{
+							"$oid": "624137fce27d0c74c40943cc"
+						},
+						{
+							"$oid": "624137f2e27d0c74c40943b5"
+						}
 					]
 				]
 			}
@@ -2324,7 +2436,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						}
 					]
 				]
 			}
@@ -2381,10 +2495,18 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad"
+						{
+							"$oid": "624122bce27d0c74c409409f"
+						},
+						{
+							"$oid": "624122b0e27d0c74c409407c"
+						},
+						{
+							"$oid": "624122bde27d0c74c40940a3"
+						},
+						{
+							"$oid": "624122b5e27d0c74c409408b"
+						}
 					]
 				]
 			}
@@ -2419,10 +2541,18 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad"
+						{
+							"$oid": "624122bce27d0c74c409409f"
+						},
+						{
+							"$oid": "624122b0e27d0c74c409407c"
+						},
+						{
+							"$oid": "624122bde27d0c74c40940a3"
+						},
+						{
+							"$oid": "624122b5e27d0c74c409408b"
+						}
 					]
 				]
 			}
@@ -2442,10 +2572,18 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"$oid": "624137f6e27d0c74c40943c2"
+						},
+						{
+							"$oid": "624135dae27d0c74c4094385"
+						},
+						{
+							"$oid": "624137fce27d0c74c40943cc"
+						},
+						{
+							"$oid": "624137f2e27d0c74c40943b5"
+						}
 					]
 				]
 			}
@@ -2465,10 +2603,18 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"$oid": "624137f6e27d0c74c40943c2"
+						},
+						{
+							"$oid": "624135dae27d0c74c4094385"
+						},
+						{
+							"$oid": "624137fce27d0c74c40943cc"
+						},
+						{
+							"$oid": "624137f2e27d0c74c40943b5"
+						}
 					]
 				]
 			}
@@ -2488,8 +2634,12 @@
 				},
 				"outcome": [
 					[
-						"623e1d098ed6651333148186",
-						"623e1d088ed665133314817d"
+						{
+							"$oid": "62414c43e27d0c74c4094562"
+						},
+						{
+							"$oid": "62414c33e27d0c74c4094531"
+						}
 					]
 				]
 			}
@@ -2509,8 +2659,12 @@
 				},
 				"outcome": [
 					[
-						"623e1d088ed6651333148181",
-						"623e1d088ed665133314817b"
+						{
+							"$oid": "62414c42e27d0c74c409455b"
+						},
+						{
+							"$oid": "62414c32e27d0c74c409452e"
+						}
 					]
 				]
 			}
@@ -2530,7 +2684,9 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"$oid": "624155217a5c14bdce6ae607"
+						}
 					]
 				]
 			}
@@ -2550,8 +2706,12 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db",
-						"623e1e3e8ed66513331481de"
+						{
+							"$oid": "624155217a5c14bdce6ae607"
+						},
+						{
+							"$oid": "624155237a5c14bdce6ae60d"
+						}
 					]
 				]
 			}
@@ -2571,7 +2731,9 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						}
 					]
 				]
 			},
@@ -2583,8 +2745,12 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						},
+						{
+							"$oid": "6241322eba30b4ebd5adc207"
+						}
 					]
 				]
 			}
@@ -2604,7 +2770,9 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						}
 					]
 				]
 			},
@@ -2616,8 +2784,12 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						},
+						{
+							"$oid": "6241322eba30b4ebd5adc207"
+						}
 					]
 				]
 			}
@@ -2637,7 +2809,9 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						}
 					]
 				]
 			},
@@ -2649,8 +2823,12 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						},
+						{
+							"$oid": "6241322eba30b4ebd5adc207"
+						}
 					]
 				]
 			}
@@ -2670,7 +2848,9 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						}
 					]
 				]
 			},
@@ -2682,8 +2862,12 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"$oid": "6241cc61e0a87a87f38b20cd"
+						},
+						{
+							"$oid": "6241322eba30b4ebd5adc207"
+						}
 					]
 				]
 			}
@@ -2718,7 +2902,9 @@
 				},
 				"outcome": [
 					[
-						"623e380a44e0512c7a91df1b"
+						{
+							"$oid": "624169287a5c14bdce6ae90b"
+						}
 					]
 				]
 			}
@@ -2754,8 +2940,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "GEOG",
-							"number": 2303
+							"$oid": "624168507a5c14bdce6ae8f2"
 						}
 					]
 				]
@@ -2823,12 +3008,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "ARAB",
-							"number": 1311
+							"$oid": "62410e6fe27d0c74c4093e7f"
 						},
 						{
-							"prefix": "ARAB",
-							"number": 1312
+							"$oid": "62410e72e27d0c74c4093e81"
 						}
 					]
 				]
@@ -2850,12 +3033,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "CHIN",
-							"number": 1311
+							"$oid": "6241389ae27d0c74c409442d"
 						},
 						{
-							"prefix": "CHIN",
-							"number": 1312
+							"$oid": "6241389fe27d0c74c4094431"
 						}
 					]
 				]
@@ -2877,12 +3058,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "FREN",
-							"number": 1311
+							"$oid": "624167907a5c14bdce6ae8ec"
 						},
 						{
-							"prefix": "FREN",
-							"number": 1312
+							"$oid": "62415ed70cef69f0ebc9c8aa"
 						}
 					]
 				]
@@ -2904,16 +3083,13 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						}
 					]
 				]
@@ -2935,20 +3111,16 @@
 				"outcome": [
 					[
 						{
-							"prefix": "SPAN",
-							"number": 1311
+							"$oid": "6241d1e9e0a87a87f38b21ab"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 1312
+							"$oid": "6241d1eae0a87a87f38b21af"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2311
+							"$oid": "6241d1eae0a87a87f38b21b1"
 						},
 						{
-							"prefix": "SPAN",
-							"number": 2312
+							"$oid": "6241d21be0a87a87f38b21b4"
 						}
 					]
 				]
@@ -2969,7 +3141,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						}
 					]
 				]
 			},
@@ -2981,8 +3155,12 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e4acee98ae00fbe8a347c"
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						},
+						{
+							"$oid": "6241d385e0a87a87f38b21d9"
+						}
 					]
 				]
 			}
@@ -3002,7 +3180,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"$oid": "6241a52fe0a87a87f38b1a6d"
+						}
 					]
 				]
 			},
@@ -3014,9 +3194,15 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba",
-						"623e3a1d44e0512c7a91dfbc",
-						"623e4acee98ae00fbe8a347c"
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						},
+						{
+							"$oid": "6241a538e0a87a87f38b1a88"
+						},
+						{
+							"$oid": "6241d385e0a87a87f38b21d9"
+						}
 					]
 				]
 			}
@@ -3036,10 +3222,14 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbc"
+						{
+							"$oid": "6241a538e0a87a87f38b1a88"
+						}
 					]
 				]
 			},
@@ -3051,7 +3241,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						}
 					]
 				]
 			},
@@ -3063,7 +3255,9 @@
 				},
 				"outcome": [
 					[
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"$oid": "6241a823e0a87a87f38b1b1b"
+						}
 					]
 				]
 			}
@@ -3083,7 +3277,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"$oid": "6241a52fe0a87a87f38b1a6d"
+						}
 					]
 				]
 			},
@@ -3095,7 +3291,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"$oid": "6241a532e0a87a87f38b1a78"
+						}
 					]
 				]
 			}
@@ -3115,12 +3313,13 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"$oid": "6241a52fe0a87a87f38b1a6d"
+						}
 					],
 					[
 						{
-							"prefix": "MATH",
-							"number": 1316
+							"$oid": "6241a531e0a87a87f38b1a74"
 						}
 					]
 				]
@@ -3141,7 +3340,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"$oid": "6241a52fe0a87a87f38b1a6d"
+						}
 					]
 				]
 			}
@@ -3161,13 +3362,18 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
 						{
-							"prefix": "MATH",
-							"number": 2333
+							"$oid": "6241a53ee0a87a87f38b1a95"
 						},
-						"623e3a1e44e0512c7a91dfc0",
-						"623e4acee98ae00fbe8a347c"
+						{
+							"$oid": "6241a541e0a87a87f38b1a9d"
+						},
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						},
+						{
+							"$oid": "6241d385e0a87a87f38b21d9"
+						}
 					]
 				]
 			},
@@ -3179,14 +3385,21 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
 						{
-							"prefix": "MATH",
-							"number": 2333
+							"$oid": "6241a53ee0a87a87f38b1a95"
 						},
-						"623e3a1e44e0512c7a91dfc0",
-						"623e4acee98ae00fbe8a347c",
-						"623e4acee98ae00fbe8a347e"
+						{
+							"$oid": "6241a541e0a87a87f38b1a9d"
+						},
+						{
+							"$oid": "6241a542e0a87a87f38b1aa3"
+						},
+						{
+							"$oid": "6241d385e0a87a87f38b21d9"
+						},
+						{
+							"$oid": "6241d385e0a87a87f38b21dc"
+						}
 					]
 				]
 			}
@@ -3206,7 +3419,9 @@
 				},
 				"outcome": [
 					[
-						"623e3f3b44e0512c7a91e056"
+						{
+							"$oid": "6241b84de0a87a87f38b1d8a"
+						}
 					]
 				]
 			}
@@ -3226,7 +3441,9 @@
 				},
 				"outcome": [
 					[
-						"623e3f3b44e0512c7a91e056"
+						{
+							"$oid": "6241b84de0a87a87f38b1d8a"
+						}
 					]
 				]
 			}
@@ -3246,7 +3463,9 @@
 				},
 				"outcome": [
 					[
-						"623e476644e0512c7a91e0d1"
+						{
+							"$oid": "6241c04fe0a87a87f38b1f33"
+						}
 					]
 				]
 			}
@@ -3266,7 +3485,9 @@
 				},
 				"outcome": [
 					[
-						"623e476644e0512c7a91e0d1"
+						{
+							"$oid": "6241c04fe0a87a87f38b1f33"
+						}
 					]
 				]
 			}
@@ -3286,10 +3507,18 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
-						"623e477d44e0512c7a91e0e1",
-						"623e477c44e0512c7a91e0de",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
+						{
+							"$oid": "6241c5b7e0a87a87f38b1f61"
+						},
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5e"
+						},
+						{
+							"$oid": "6241c5c0e0a87a87f38b1f78"
+						}
 					]
 				]
 			}
@@ -3309,10 +3538,18 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
-						"623e477d44e0512c7a91e0e1",
-						"623e477c44e0512c7a91e0de",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5c"
+						},
+						{
+							"$oid": "6241c5b7e0a87a87f38b1f61"
+						},
+						{
+							"$oid": "6241c5b6e0a87a87f38b1f5e"
+						},
+						{
+							"$oid": "6241c5c0e0a87a87f38b1f78"
+						}
 					]
 				]
 			}
@@ -3332,7 +3569,9 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"$oid": "6241c9abe0a87a87f38b204b"
+						}
 					]
 				]
 			}
@@ -3353,8 +3592,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "THEA",
-							"number": 1310
+							"$oid": "6241df95e0a87a87f38b226d"
 						}
 					]
 				]
@@ -3376,8 +3614,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "THEA",
-							"number": 1310
+							"$oid": "6241df95e0a87a87f38b226d"
 						}
 					]
 				]
@@ -3399,8 +3636,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "AHST",
-							"number": 2331
+							"$oid": "62410d50e27d0c74c4093e65"
 						}
 					]
 				]
@@ -3422,8 +3658,7 @@
 				"outcome": [
 					[
 						{
-							"prefix": "AHST",
-							"number": 2331
+							"$oid": "62410d50e27d0c74c4093e65"
 						}
 					]
 				]
@@ -3444,7 +3679,9 @@
 				},
 				"outcome": [
 					[
-						"623e27408ed665133314823f"
+						{
+							"$oid": "624164507a5c14bdce6ae845"
+						}
 					]
 				]
 			}
@@ -3464,7 +3701,9 @@
 				},
 				"outcome": [
 					[
-						"623e27408ed665133314823f"
+						{
+							"$oid": "624164507a5c14bdce6ae845"
+						}
 					]
 				]
 			}
@@ -3482,7 +3721,9 @@
 				},
 				"outcome": [
 					[
-						"623e3a1c44e0512c7a91dfb6"
+						{
+							"$oid": "6241a52ee0a87a87f38b1a6a"
+						}
 					]
 				]
 			},
@@ -3494,10 +3735,11 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8",
 						{
-							"prefix": "MATH",
-							"number": 1316
+							"$oid": "6241a52fe0a87a87f38b1a6d"
+						},
+						{
+							"$oid": "6241a531e0a87a87f38b1a74"
 						}
 					]
 				]
@@ -3510,12 +3752,15 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba",
 						{
-							"prefix": "MATH",
-							"number": 2306
+							"$oid": "6241a532e0a87a87f38b1a78"
 						},
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"$oid": "6240b438ddc4b627a73c07d3"
+						},
+						{
+							"$oid": "6241a53ee0a87a87f38b1a95"
+						}
 					]
 				]
 			},
@@ -3528,12 +3773,10 @@
 				"outcome": [
 					[
 						{
-							"prefix": "MATH",
-							"number": 2370
+							"$oid": "6241a542e0a87a87f38b1aa1"
 						},
 						{
-							"prefix": "MATH",
-							"number": 2423
+							"$oid": "6241a542e0a87a87f38b1aa3"
 						}
 					]
 				]
@@ -3546,7 +3789,9 @@
 				},
 				"outcome": [
 					[
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"$oid": "6241a823e0a87a87f38b1b1b"
+						}
 					]
 				]
 			}

--- a/scraper/data/Exams.json
+++ b/scraper/data/Exams.json
@@ -1,0 +1,2255 @@
+[
+    {
+        "type": "AP",
+        "exams": [
+            {
+                "examType": "AP",
+                "name": "History of Art",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Studio Art: 2-D Design",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "ARTS",
+                            "number": 2380
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "ARTS",
+                            "number": 2380
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Studio Art: Drawing",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "ARTS",
+                            "number": 1316
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "ARTS",
+                            "number": 1316
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "General Biology",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2281
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "General Chemistry",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "Lab"
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "Labs"
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Chinese Language & Culture",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 1312
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 2311
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Computer Science A",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "CS",
+                            "number": 1336
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1337
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "CS",
+                            "number": 1336
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1337
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Macroeconomics",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Microeconomics",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "English Language and Composition",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "English Literature and Composition",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "LIT",
+                            "number": 2331
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "LIT",
+                            "number": 2331
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "French Language",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 2311
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Human Geography",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "German Language",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 2311
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Comp Government and Politics",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "US Government and Politics",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "United States History",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "HIST",
+                            "number": 1302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "HIST",
+                            "number": 1302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Japanese Language & Culture",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "JAPN",
+                            "number": 1311
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "JAPN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "JAPN",
+                            "number": 1312
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "JAPN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "JAPN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "JAPN",
+                            "number": 2311
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Calculus AB",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Calculus BC",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2414
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2414
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Music Theory",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "MUSI",
+                            "number": 2328
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "MUSI",
+                            "number": 2328
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "MUSI",
+                            "number": 2328
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Physics B (non-calculus)",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Physics 1",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Physics 2",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Physics C: Mechanics",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2325
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2325
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Physics C: Electrical and Magnetic",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2326,
+                            "special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2326,
+                            "special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "General Psychology",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Spanish Language & Culture",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Spanish Literature & Culture",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "AP",
+                "name": "Statistics",
+                "yields": {
+                    "3": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH free electives"
+                        }
+                    ],
+                    "4": [
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "type": "CLEP",
+        "exams": [
+            {
+                "examType": "CLEP",
+                "name": "College French Level 1 (2 semesters)",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College Level French Level 2 (4 semesters)",
+                "yields": {
+                    "58": [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College German Level 1 (2 semesters)",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College Level German Level 2 (4 semesters)",
+                "yields": {
+                    "58": [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College Spanish Level 1 (2 semesters)*",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College Spanish Level 2 (3 semesters)",
+                "yields": {
+                    "60": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College Spanish with Writing (4 semesters)",
+                "yields": {
+                    "65": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "American Government",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "American History I: Early Colonization to 1877",
+                "yields": {
+                    "60": [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "American History II: 1865 to Present",
+                "yields": {
+                    "60": [
+                        {
+                            "prefix": "HIST",
+                            "number": 1302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Human Growth and Development",
+                "yields": {
+                    "57": [
+                        {
+                            "prefix": "PSY",
+                            "number": 2314
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Introduction to Educational Psychology",
+                "yields": {
+                    "57": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH Psychology elective credit"
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Introductory Macroeconomics",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Introductory Microeconomics",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Introductory Psychology",
+                "yields": {
+                    "57": [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Western Civilization I: Ancient Near East to 1648",
+                "yields": {
+                    "60": [
+                        {
+                            "prefix": "HUMA",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Western Civilization II: 1648 to Present",
+                "yields": {
+                    "60": [
+                        {
+                            "prefix": "HUMA",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Calculus with Elementary Functions",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ],
+                    "61": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "College Algebra",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "General Biology",
+                "yields": {
+                    "56": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "General Chemistry",
+                "yields": {
+                    "60": [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        }
+                    ],
+                    "70": [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Pre-calculus",
+                "yields": {
+                    "58": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "CLEP",
+                "name": "Information Systems and Computer Applications",
+                "yields": {
+                    "50": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH Business Computer Information Systems elective credit"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "type": "IB",
+        "exams": [
+            {
+                "examType": "IB",
+                "name": "Biology",
+                "level": "Standard",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 1300
+                        }
+                    ],
+                    "7": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Biology",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 1300
+                        }
+                    ],
+                    "6": [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Chemistry",
+                "level": "Standard",
+                "yields": {
+                    "7": [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Chemistry",
+                "level": "Higher",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Computer Science",
+                "level": "Higher",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "CS",
+                            "number": 1336
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1136
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Computer Science",
+                "level": "Standard",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "CS",
+                            "number": 1334
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1134
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Economics",
+                "level": "Standard",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Economics",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        },
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Language A: Literature",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Language A: Literature",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Language A: Language and Literature",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Language A: Language and Literature",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Environmental Systems and Societies",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH Geoscience elective credit"
+                        }
+                    ],
+                    "6": [
+                        {
+                            "prefix": "GEOS",
+                            "number": 2302
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Geography",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH Geography elective credit"
+                        }
+                    ],
+                    "5": [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "History (Any Regional Area)",
+                "level": "Higher",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "6 SCH History elective Credit"
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Any B languange offered by UTD",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": null,
+                            "number": null,
+                            "special": "3 SCH Language elective Credit"
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Arabic B",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "ARAB",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "ARAB",
+                            "number": 1312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Chinese B",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 1312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Frence B",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Spanish (A or B)",
+                "level": "Standard",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Spanish (A or B)",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Mathematics",
+                "level": "Standard",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ],
+                    "7": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Mathematics",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ],
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Mathematics Analysis and Approaches",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        }
+                    ],
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ],
+                    "7": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Mathematics Analysis and Approaches",
+                "level": "Standard",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ],
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Mathematics Applications and Interpretations",
+                "level": "Higher",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1316
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Mathematics Applications and Interpretations",
+                "level": "Standard",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Further Mathematics",
+                "level": "Higher",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2333
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ],
+                    "7": [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2333
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 2332
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Music",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "MUSI",
+                            "number": 1306
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Music",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "MUSI",
+                            "number": 1306
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Philosophy",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "PHIL",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Philosophy",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "PHIL",
+                            "number": 1301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Physics",
+                "level": "Standard",
+                "yields": {
+                    "7": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Physics",
+                "level": "Higher",
+                "yields": {
+                    "6": [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Psychology",
+                "level": "Higher",
+                "yields": {
+                    "5": [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Theatre",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "THEA",
+                            "number": 1310
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Theatre",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "THEA",
+                            "number": 1310
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Visual Arts",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Visual Arts",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Film",
+                "level": "Standard",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "FILM",
+                            "number": 2332
+                        }
+                    ]
+                }
+            },
+            {
+                "examType": "IB",
+                "name": "Film",
+                "level": "Higher",
+                "yields": {
+                    "4": [
+                        {
+                            "prefix": "FILM",
+                            "number": 2332
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "examType": "ALEKS",
+        "placement": {
+            "35": [
+                {
+                    "prefix": "MATH",
+                    "number": 1306
+                }
+            ],
+            "50": [
+                {
+                    "prefix": "MATH",
+                    "number": 1314
+                },
+                {
+                    "prefix": "MATH",
+                    "number": 1316
+                }
+            ],
+            "70": [
+                {
+                    "prefix": "MATH",
+                    "number": 1325
+                },
+                {
+                    "prefix": "MATH",
+                    "number": 2306
+                },
+                {
+                    "prefix": "MATH",
+                    "number": 2312
+                }
+            ],
+            "80": [
+                {
+                    "prefix": "MATH",
+                    "number": 2370
+                },
+                {
+                    "prefix": "MATH",
+                    "number": 2423
+                }
+            ],
+            "85": [
+                {
+                    "prefix": "MATH",
+                    "number": 2417
+                }
+            ]
+        }
+    }
+]

--- a/scraper/data/ExamsWithoutObjectIds.json
+++ b/scraper/data/ExamsWithoutObjectIds.json
@@ -4060,7 +4060,7 @@
 						},
 						{
 							"prefix": "MATH",
-							"number": 2423
+							"number": 2413
 						}
 					]
 				]

--- a/scraper/data/ExamsWithoutObjectIds.json
+++ b/scraper/data/ExamsWithoutObjectIds.json
@@ -1,4085 +1,4625 @@
 [
-	{
-		"_id": "623f8ef656965e1884291c17",
-		"type": "AP",
-		"name": "History of Art",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c17",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c17",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "AHST",
-							"number": 2331
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c17",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "AHST",
-							"number": 2331
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c18",
-		"type": "AP",
-		"name": "Studio Art: 2-D Design",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c18",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c18",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ARTS",
-							"number": 2380
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c18",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ARTS",
-							"number": 2380
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c19",
-		"type": "AP",
-		"name": "Studio Art: Drawing",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c19",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c19",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ARTS",
-							"number": 1316
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c19",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ARTS",
-							"number": 1316
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c1a",
-		"type": "AP",
-		"name": "General Biology",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1a",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1a",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 2312
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2112
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2311
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2111
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1a",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 2312
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2112
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2311
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2111
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2281
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c1b",
-		"type": "AP",
-		"name": "General Chemistry",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1b",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1b",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHEM",
-							"number": 1311
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1111
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1b",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHEM",
-							"number": 1311
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1111
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1312
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c1c",
-		"type": "AP",
-		"name": "Chinese Language & Culture",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1c",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHIN",
-							"number": 1311
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1c",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHIN",
-							"number": 1311
-						},
-						{
-							"prefix": "CHIN",
-							"number": 1312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1c",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHIN",
-							"number": 1311
-						},
-						{
-							"prefix": "CHIN",
-							"number": 1312
-						},
-						{
-							"prefix": "CHIN",
-							"number": 2311
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c1d",
-		"type": "AP",
-		"name": "Computer Science A",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1d",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1d",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CS",
-							"number": 1336
-						},
-						{
-							"prefix": "CS",
-							"number": 1337
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1d",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CS",
-							"number": 1336
-						},
-						{
-							"prefix": "CS",
-							"number": 1337
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c1e",
-		"type": "AP",
-		"name": "Macroeconomics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1e",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1e",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2301
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1e",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c1f",
-		"type": "AP",
-		"name": "Microeconomics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1f",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1f",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c1f",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c20",
-		"type": "AP",
-		"name": "English Language and Composition",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c20",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c20",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c20",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c21",
-		"type": "AP",
-		"name": "English Literature and Composition",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c21",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c21",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "LIT",
-							"number": 2331
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c21",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "LIT",
-							"number": 2331
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c22",
-		"type": "AP",
-		"name": "French Language",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c22",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FREN",
-							"number": 1311
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c22",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FREN",
-							"number": 1311
-						},
-						{
-							"prefix": "FREN",
-							"number": 1312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c22",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FREN",
-							"number": 1311
-						},
-						{
-							"prefix": "FREN",
-							"number": 1312
-						},
-						{
-							"prefix": "FREN",
-							"number": 2311
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c23",
-		"type": "AP",
-		"name": "Human Geography",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c23",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GEOG",
-							"number": 2303
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c23",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GEOG",
-							"number": 2303
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c23",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GEOG",
-							"number": 2303
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c24",
-		"type": "AP",
-		"name": "German Language",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c24",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GERM",
-							"number": 1311
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c24",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GERM",
-							"number": 1311
-						},
-						{
-							"prefix": "GERM",
-							"number": 1312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c24",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GERM",
-							"number": 1311
-						},
-						{
-							"prefix": "GERM",
-							"number": 1312
-						},
-						{
-							"prefix": "GERM",
-							"number": 2311
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c25",
-		"type": "AP",
-		"name": "Comp Government and Politics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c25",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c25",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c25",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c26",
-		"type": "AP",
-		"name": "US Government and Politics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c26",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GOVT",
-							"number": 2305
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c26",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GOVT",
-							"number": 2305
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c26",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GOVT",
-							"number": 2305
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c27",
-		"type": "AP",
-		"name": "United States History",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c27",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HIST",
-							"number": 1301
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c27",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HIST",
-							"number": 1301
-						},
-						{
-							"prefix": "HIST",
-							"number": 1302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c27",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HIST",
-							"number": 1301
-						},
-						{
-							"prefix": "HIST",
-							"number": 1302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c28",
-		"type": "AP",
-		"name": "Japanese Language & Culture",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c28",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "JAPN",
-							"number": 1311
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c28",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "JAPN",
-							"number": 1311
-						},
-						{
-							"prefix": "JAPN",
-							"number": 1312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c28",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "JAPN",
-							"number": 1311
-						},
-						{
-							"prefix": "JAPN",
-							"number": 1312
-						},
-						{
-							"prefix": "JAPN",
-							"number": 2311
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c29",
-		"type": "AP",
-		"name": "Calculus AB",
-		"yields": [
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Calculus BC",
-					"required": 2,
-					"options": [
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c29",
-							"minimumscore": 3
-						},
-						{
-							"type": "other",
-							"description": "AP Math Exam Credit",
-							"condition": "Students can receive credit for only one AP Math exam"
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Calculus BC",
-					"required": 2,
-					"options": [
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c29",
-							"minimumscore": 4
-						},
-						{
-							"type": "other",
-							"description": "AP Math Exam Credit",
-							"condition": "Students can receive credit for only one AP Math exam"
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 1325
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Calculus BC",
-					"required": 2,
-					"options": [
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c29",
-							"minimumscore": 5
-						},
-						{
-							"type": "other",
-							"description": "AP Math Exam Credit",
-							"condition": "Students can receive credit for only one AP Math exam"
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 1325
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c2a",
-		"type": "AP",
-		"name": "Calculus BC",
-		"yields": [
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Calculus BC",
-					"required": 3,
-					"options": [
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c2a",
-							"minimumscore": 3
-						},
-						{
-							"type": "other",
-							"description": "AP Math Exam Credit",
-							"condition": "Students can receive credit for only one AP Math exam"
-						},
-						{
-							"type": "other",
-							"description": "AP Calculus BC: AB subscore",
-							"condition": "Requires an AB subscore of 4 or 5."
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 1325
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Calculus BC",
-					"required": 2,
-					"options": [
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c2a",
-							"minimumscore": 4
-						},
-						{
-							"type": "other",
-							"description": "AP Math Exam Credit",
-							"condition": "Students can receive credit for only one AP Math exam"
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2417
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 1325
-						},
-						{
-							"prefix": "MATH",
-							"number": 1326
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 2413
-						},
-						{
-							"prefix": "MATH",
-							"number": 2414
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Calculus BC",
-					"required": 2,
-					"options": [
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c2a",
-							"minimumscore": 5
-						},
-						{
-							"type": "other",
-							"description": "AP Math Exam Credit",
-							"condition": "Students can receive credit for only one AP Math exam"
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2417
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 1325
-						},
-						{
-							"prefix": "MATH",
-							"number": 1326
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 2413
-						},
-						{
-							"prefix": "MATH",
-							"number": 2414
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c2b",
-		"type": "AP",
-		"name": "Music Theory",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2b",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MUSI",
-							"number": 2328
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2b",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MUSI",
-							"number": 2328
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2b",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MUSI",
-							"number": 2328
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c2c",
-		"type": "AP",
-		"name": "Physics B (non-calculus)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2c",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2c",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1101
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2c",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1101
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c2d",
-		"type": "AP",
-		"name": "Physics 1",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2d",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2d",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1101
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2d",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1101
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c2e",
-		"type": "AP",
-		"name": "Physics 2",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2e",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2e",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1101
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2e",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1101
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c2f",
-		"type": "AP",
-		"name": "Physics C: Mechanics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2f",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2f",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 2325
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2125
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c2f",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 2325
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2125
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c30",
-		"type": "AP",
-		"name": "Physics C: Electrical and Magnetic",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c30",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Physics C: Electrical and Magnetic",
-					"required": 2,
-					"options": [
-						{
-							"type": "collection",
-							"name": "AP Physics C: Electrical and Magnetic for Physics Majors",
-							"required": 1,
-							"options": [
-								{
-									"type": "collection",
-									"name": "AP Physics C: Electrical and Magnetic for Physics Majors",
-									"required": 2,
-									"options": [
-										{
-											"type": "major",
-											"major": "Physics"
-										},
-										{
-											"type": "course",
-											"class_reference": {
-												"prefix": "PHYS",
-												"number": 3416
-											},
-											"minimum_grade": "C"
-										}
-									]
-								},
-								{
-									"type": "major",
-									"major": "Physics",
-									"exclude": true
-								}
-							]
-						},
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c30",
-							"minimumscore": 4
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 2326,
-							"special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2126
-						}
-					],
-					[
-						{
-							"category": "free",
-							"credit_hours": 4
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "collection",
-					"name": "AP Physics C: Electrical and Magnetic",
-					"required": 2,
-					"options": [
-						{
-							"type": "collection",
-							"name": "AP Physics C: Electrical and Magnetic for Physics Majors",
-							"required": 1,
-							"options": [
-								{
-									"type": "collection",
-									"name": "AP Physics C: Electrical and Magnetic for Physics Majors",
-									"required": 2,
-									"options": [
-										{
-											"type": "major",
-											"major": "Physics"
-										},
-										{
-											"type": "course",
-											"class_reference": {
-												"prefix": "PHYS",
-												"number": 3416
-											},
-											"minimum_grade": "C"
-										}
-									]
-								},
-								{
-									"type": "major",
-									"major": "Physics",
-									"exclude": true
-								}
-							]
-						},
-						{
-							"type": "exam",
-							"examReference": "623f8ef656965e1884291c30",
-							"minimumscore": 5
-						}
-					]
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 2326,
-							"special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2126
-						}
-					],
-					[
-						{
-							"category": "free",
-							"credit_hours": 4
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c31",
-		"type": "AP",
-		"name": "General Psychology",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c31",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c31",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PSY",
-							"number": 2301
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c31",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PSY",
-							"number": 2301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c32",
-		"type": "AP",
-		"name": "Spanish Language & Culture",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c32",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c32",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c32",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c33",
-		"type": "AP",
-		"name": "Spanish Literature & Culture",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c33",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c33",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c33",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c34",
-		"type": "AP",
-		"name": "Statistics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c34",
-					"minimumscore": 3
-				},
-				"outcome": [
-					[
-						{
-							"category": "free",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c34",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "STAT",
-							"number": 1342
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c34",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "STAT",
-							"number": 1342
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c35",
-		"type": "CLEP",
-		"name": "College French Level 1 (2 semesters)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c35",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FREN",
-							"number": 1311
-						},
-						{
-							"prefix": "FREN",
-							"number": 1312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c36",
-		"type": "CLEP",
-		"name": "College Level French Level 2 (4 semesters)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c36",
-					"minimumscore": 58
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FREN",
-							"number": 1311
-						},
-						{
-							"prefix": "FREN",
-							"number": 1312
-						},
-						{
-							"prefix": "FREN",
-							"number": 2311
-						},
-						{
-							"prefix": "FREN",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c37",
-		"type": "CLEP",
-		"name": "College German Level 1 (2 semesters)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c37",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GERM",
-							"number": 1311
-						},
-						{
-							"prefix": "GERM",
-							"number": 1312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c38",
-		"type": "CLEP",
-		"name": "College Level German Level 2 (4 semesters)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c38",
-					"minimumscore": 58
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GERM",
-							"number": 1311
-						},
-						{
-							"prefix": "GERM",
-							"number": 1312
-						},
-						{
-							"prefix": "GERM",
-							"number": 2311
-						},
-						{
-							"prefix": "GERM",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c39",
-		"type": "CLEP",
-		"name": "College Spanish Level 1 (2 semesters)*",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c39",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c3a",
-		"type": "CLEP",
-		"name": "College Spanish Level 2 (3 semesters)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3a",
-					"minimumscore": 60
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c3b",
-		"type": "CLEP",
-		"name": "College Spanish with Writing (4 semesters)",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3b",
-					"minimumscore": 65
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c3c",
-		"type": "CLEP",
-		"name": "American Government",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3c",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GOVT",
-							"number": 2305
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c3d",
-		"type": "CLEP",
-		"name": "American History I: Early Colonization to 1877",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3d",
-					"minimumscore": 60
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HIST",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c3e",
-		"type": "CLEP",
-		"name": "American History II: 1865 to Present",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3e",
-					"minimumscore": 60
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HIST",
-							"number": 1302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c3f",
-		"type": "CLEP",
-		"name": "Human Growth and Development",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c3f",
-					"minimumscore": 57
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PSY",
-							"number": 2314
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c40",
-		"type": "CLEP",
-		"name": "Introduction to Educational Psychology",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c40",
-					"minimumscore": 57
-				},
-				"outcome": [
-					[
-						{
-							"category": "Psychology",
-							"credit_hours": 3
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c41",
-		"type": "CLEP",
-		"name": "Introductory Macroeconomics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c41",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c42",
-		"type": "CLEP",
-		"name": "Introductory Microeconomics",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c42",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c43",
-		"type": "CLEP",
-		"name": "Introductory Psychology",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c43",
-					"minimumscore": 57
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PSY",
-							"number": 2301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c44",
-		"type": "CLEP",
-		"name": "Western Civilization I: Ancient Near East to 1648",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c44",
-					"minimumscore": 60
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HUMA",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c45",
-		"type": "CLEP",
-		"name": "Western Civilization II: 1648 to Present",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c45",
-					"minimumscore": 60
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "HUMA",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c46",
-		"type": "CLEP",
-		"name": "Calculus with Elementary Functions",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c46",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c46",
-					"minimumscore": 61
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2417
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c47",
-		"type": "CLEP",
-		"name": "College Algebra",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c47",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1314
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c48",
-		"type": "CLEP",
-		"name": "General Biology",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c48",
-					"minimumscore": 56
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 2311
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2111
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2312
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c49",
-		"type": "CLEP",
-		"name": "General Chemistry",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c49",
-					"minimumscore": 60
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHEM",
-							"number": 1311
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1111
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c49",
-					"minimumscore": 70
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHEM",
-							"number": 1311
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1111
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1312
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c4a",
-		"type": "CLEP",
-		"name": "Pre-calculus",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4a",
-					"minimumscore": 58
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c4b",
-		"type": "CLEP",
-		"name": "Information Systems and Computer Applications",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4b",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"category": "Business Computer Information Systems",
-							"credit_hours": 3
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c4c",
-		"type": "IB",
-		"name": "Biology",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4c",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 1300
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4c",
-					"minimumscore": 7
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 2311
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2111
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2312
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c4d",
-		"type": "IB",
-		"name": "Biology",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4d",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 1300
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4d",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "BIOL",
-							"number": 2311
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2111
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2312
-						},
-						{
-							"prefix": "BIOL",
-							"number": 2112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c4e",
-		"type": "IB",
-		"name": "Chemistry",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4e",
-					"minimumscore": 7
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHEM",
-							"number": 1311
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1111
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1312
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c4f",
-		"type": "IB",
-		"name": "Chemistry",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c4f",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHEM",
-							"number": 1311
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1111
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1312
-						},
-						{
-							"prefix": "CHEM",
-							"number": 1112
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c50",
-		"type": "IB",
-		"name": "Computer Science",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c50",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CS",
-							"number": 1336
-						},
-						{
-							"prefix": "CS",
-							"number": 1136
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c51",
-		"type": "IB",
-		"name": "Computer Science",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c51",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CS",
-							"number": 1334
-						},
-						{
-							"prefix": "CS",
-							"number": 1134
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c52",
-		"type": "IB",
-		"name": "Economics",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c52",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c53",
-		"type": "IB",
-		"name": "Economics",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c53",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ECON",
-							"number": 2301
-						},
-						{
-							"prefix": "ECON",
-							"number": 2302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c54",
-		"type": "IB",
-		"name": "Language A: Literature",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c54",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c54",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						},
-						{
-							"prefix": "LIT",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c55",
-		"type": "IB",
-		"name": "Language A: Literature",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c55",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c55",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						},
-						{
-							"prefix": "LIT",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c56",
-		"type": "IB",
-		"name": "Language A: Language and Literature",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c56",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c56",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						},
-						{
-							"prefix": "LIT",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c57",
-		"type": "IB",
-		"name": "Language A: Language and Literature",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c57",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c57",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "RHET",
-							"number": 1302
-						},
-						{
-							"prefix": "LIT",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c58",
-		"type": "IB",
-		"name": "Environmental Systems and Societies",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c58",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"category": "Geoscience",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c58",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GEOS",
-							"number": 2302
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c59",
-		"type": "IB",
-		"name": "Geography",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c59",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"category": "Geography",
-							"credit_hours": 3
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c59",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "GEOG",
-							"number": 2303
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c5a",
-		"type": "IB",
-		"name": "History (Any Regional Area)",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5a",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"category": "History",
-							"credit_hours": 6
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c5b",
-		"type": "IB",
-		"name": "Any B languange offered by UTD",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5b",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"category": "Language",
-							"credit_hours": 3
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c5c",
-		"type": "IB",
-		"name": "Arabic B",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5c",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "ARAB",
-							"number": 1311
-						},
-						{
-							"prefix": "ARAB",
-							"number": 1312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c5d",
-		"type": "IB",
-		"name": "Chinese B",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5d",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "CHIN",
-							"number": 1311
-						},
-						{
-							"prefix": "CHIN",
-							"number": 1312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c5e",
-		"type": "IB",
-		"name": "Frence B",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5e",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FREN",
-							"number": 1311
-						},
-						{
-							"prefix": "FREN",
-							"number": 1312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c5f",
-		"type": "IB",
-		"name": "Spanish (A or B)",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c5f",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c60",
-		"type": "IB",
-		"name": "Spanish (A or B)",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c60",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "SPAN",
-							"number": 1311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 1312
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2311
-						},
-						{
-							"prefix": "SPAN",
-							"number": 2312
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c61",
-		"type": "IB",
-		"name": "Mathematics",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c61",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c61",
-					"minimumscore": 7
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "STAT",
-							"number": 1342
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c62",
-		"type": "IB",
-		"name": "Mathematics",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c62",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1314
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c62",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1325
-						},
-						{
-							"prefix": "MATH",
-							"number": 1326
-						},
-						{
-							"prefix": "STAT",
-							"number": 1342
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c63",
-		"type": "IB",
-		"name": "Mathematics Analysis and Approaches",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c63",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1325
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 1326
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c63",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2413
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c63",
-					"minimumscore": 7
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2417
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c64",
-		"type": "IB",
-		"name": "Mathematics Analysis and Approaches",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c64",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1314
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c64",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1325
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c65",
-		"type": "IB",
-		"name": "Mathematics Applications and Interpretations",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c65",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1314
-						}
-					],
-					[
-						{
-							"prefix": "MATH",
-							"number": 1316
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c66",
-		"type": "IB",
-		"name": "Mathematics Applications and Interpretations",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c66",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1314
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c67",
-		"type": "IB",
-		"name": "Further Mathematics",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c67",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2333
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						},
-						{
-							"prefix": "STAT",
-							"number": 1342
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c67",
-					"minimumscore": 7
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2312
-						},
-						{
-							"prefix": "MATH",
-							"number": 2333
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						},
-						{
-							"prefix": "STAT",
-							"number": 1342
-						},
-						{
-							"prefix": "STAT",
-							"number": 2332
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c68",
-		"type": "IB",
-		"name": "Music",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c68",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MUSI",
-							"number": 1306
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c69",
-		"type": "IB",
-		"name": "Music",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c69",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MUSI",
-							"number": 1306
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c6a",
-		"type": "IB",
-		"name": "Philosophy",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6a",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHIL",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c6b",
-		"type": "IB",
-		"name": "Philosophy",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6b",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHIL",
-							"number": 1301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c6c",
-		"type": "IB",
-		"name": "Physics",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6c",
-					"minimumscore": 7
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2125
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1302
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2126
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c6d",
-		"type": "IB",
-		"name": "Physics",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6d",
-					"minimumscore": 6
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PHYS",
-							"number": 1301
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2125
-						},
-						{
-							"prefix": "PHYS",
-							"number": 1302
-						},
-						{
-							"prefix": "PHYS",
-							"number": 2126
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c6e",
-		"type": "IB",
-		"name": "Psychology",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6e",
-					"minimumscore": 5
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "PSY",
-							"number": 2301
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c6f",
-		"type": "IB",
-		"name": "Theatre",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c6f",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "THEA",
-							"number": 1310
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c70",
-		"type": "IB",
-		"name": "Theatre",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c70",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "THEA",
-							"number": 1310
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c71",
-		"type": "IB",
-		"name": "Visual Arts",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c71",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "AHST",
-							"number": 2331
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c72",
-		"type": "IB",
-		"name": "Visual Arts",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c72",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "AHST",
-							"number": 2331
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c73",
-		"type": "IB",
-		"name": "Film",
-		"level": "Standard",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c73",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FILM",
-							"number": 2332
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c74",
-		"type": "IB",
-		"name": "Film",
-		"level": "Higher",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c74",
-					"minimumscore": 4
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "FILM",
-							"number": 2332
-						}
-					]
-				]
-			}
-		]
-	},
-	{
-		"_id": "623f8ef656965e1884291c75",
-		"type": "ALEKS",
-		"yields": [
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
-					"minimumscore": 35
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1306
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
-					"minimumscore": 50
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1314
-						},
-						{
-							"prefix": "MATH",
-							"number": 1316
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
-					"minimumscore": 70
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 1325
-						},
-						{
-							"prefix": "MATH",
-							"number": 2306
-						},
-						{
-							"prefix": "MATH",
-							"number": 2312
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
-					"minimumscore": 80
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2370
-						},
-						{
-							"prefix": "MATH",
-							"number": 2413
-						}
-					]
-				]
-			},
-			{
-				"requirement": {
-					"type": "exam",
-					"examReference": "623f8ef656965e1884291c75",
-					"minimumscore": 85
-				},
-				"outcome": [
-					[
-						{
-							"prefix": "MATH",
-							"number": 2417
-						}
-					]
-				]
-			}
-		]
-	}
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c17"
+        },
+        "type": "AP",
+        "name": "History of Art",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c17"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c17"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c17"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c18"
+        },
+        "type": "AP",
+        "name": "Studio Art: 2-D Design",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c18"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c18"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ARTS",
+                            "number": 2380
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c18"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ARTS",
+                            "number": 2380
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c19"
+        },
+        "type": "AP",
+        "name": "Studio Art: Drawing",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c19"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c19"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ARTS",
+                            "number": 1316
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c19"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ARTS",
+                            "number": 1316
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c1a"
+        },
+        "type": "AP",
+        "name": "General Biology",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1a"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1a"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1a"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2281
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c1b"
+        },
+        "type": "AP",
+        "name": "General Chemistry",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1b"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1b"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1b"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c1c"
+        },
+        "type": "AP",
+        "name": "Chinese Language & Culture",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1c"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1c"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1c"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c1d"
+        },
+        "type": "AP",
+        "name": "Computer Science A",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1d"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1d"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CS",
+                            "number": 1336
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1337
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1d"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CS",
+                            "number": 1336
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1337
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c1e"
+        },
+        "type": "AP",
+        "name": "Macroeconomics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1e"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1e"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1e"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c1f"
+        },
+        "type": "AP",
+        "name": "Microeconomics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1f"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1f"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c1f"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c20"
+        },
+        "type": "AP",
+        "name": "English Language and Composition",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c20"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c20"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c20"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c21"
+        },
+        "type": "AP",
+        "name": "English Literature and Composition",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c21"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c21"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "LIT",
+                            "number": 2331
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c21"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "LIT",
+                            "number": 2331
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c22"
+        },
+        "type": "AP",
+        "name": "French Language",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c22"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c22"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c22"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c23"
+        },
+        "type": "AP",
+        "name": "Human Geography",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c23"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c23"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c23"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c24"
+        },
+        "type": "AP",
+        "name": "German Language",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c24"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c24"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c24"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c25"
+        },
+        "type": "AP",
+        "name": "Comp Government and Politics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c25"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c25"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c25"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c26"
+        },
+        "type": "AP",
+        "name": "US Government and Politics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c26"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c26"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c26"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c27"
+        },
+        "type": "AP",
+        "name": "United States History",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c27"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c27"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "HIST",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c27"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "HIST",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c28"
+        },
+        "type": "AP",
+        "name": "Japanese Language & Culture",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c28"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "JAPN",
+                            "number": 1311
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c28"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "JAPN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "JAPN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c28"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "JAPN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "JAPN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "JAPN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c29"
+        },
+        "type": "AP",
+        "name": "Calculus AB",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Calculus BC",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c29"
+                            },
+                            "minimumscore": 3
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Math Exam Credit",
+                            "condition": "Students can receive credit for only one AP Math exam"
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Calculus BC",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c29"
+                            },
+                            "minimumscore": 4
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Math Exam Credit",
+                            "condition": "Students can receive credit for only one AP Math exam"
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Calculus BC",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c29"
+                            },
+                            "minimumscore": 5
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Math Exam Credit",
+                            "condition": "Students can receive credit for only one AP Math exam"
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c2a"
+        },
+        "type": "AP",
+        "name": "Calculus BC",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Calculus BC",
+                    "required": 3,
+                    "options": [
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c2a"
+                            },
+                            "minimumscore": 3
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Math Exam Credit",
+                            "condition": "Students can receive credit for only one AP Math exam"
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Calculus BC: AB subscore",
+                            "condition": "Requires an AB subscore of 4 or 5."
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Calculus BC",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c2a"
+                            },
+                            "minimumscore": 4
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Math Exam Credit",
+                            "condition": "Students can receive credit for only one AP Math exam"
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2414
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Calculus BC",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c2a"
+                            },
+                            "minimumscore": 5
+                        },
+                        {
+                            "type": "other",
+                            "description": "AP Math Exam Credit",
+                            "condition": "Students can receive credit for only one AP Math exam"
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2414
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c2b"
+        },
+        "type": "AP",
+        "name": "Music Theory",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2b"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MUSI",
+                            "number": 2328
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2b"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MUSI",
+                            "number": 2328
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2b"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MUSI",
+                            "number": 2328
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c2c"
+        },
+        "type": "AP",
+        "name": "Physics B (non-calculus)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2c"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2c"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2c"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c2d"
+        },
+        "type": "AP",
+        "name": "Physics 1",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2d"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2d"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2d"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c2e"
+        },
+        "type": "AP",
+        "name": "Physics 2",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2e"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2e"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2e"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1101
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c2f"
+        },
+        "type": "AP",
+        "name": "Physics C: Mechanics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2f"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2f"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2325
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c2f"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2325
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c30"
+        },
+        "type": "AP",
+        "name": "Physics C: Electrical and Magnetic",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c30"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Physics C: Electrical and Magnetic",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "collection",
+                            "name": "AP Physics C: Electrical and Magnetic for Physics Majors",
+                            "required": 1,
+                            "options": [
+                                {
+                                    "type": "collection",
+                                    "name": "AP Physics C: Electrical and Magnetic for Physics Majors",
+                                    "required": 2,
+                                    "options": [
+                                        {
+                                            "type": "major",
+                                            "major": "Physics"
+                                        },
+                                        {
+                                            "type": "course",
+                                            "class_reference": {
+                                                "prefix": "PHYS",
+                                                "number": 3416
+                                            },
+                                            "minimum_grade": "C"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "major",
+                                    "major": "Physics",
+                                    "exclude": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c30"
+                            },
+                            "minimumscore": 4
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2326,
+                            "special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ],
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 4
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "collection",
+                    "name": "AP Physics C: Electrical and Magnetic",
+                    "required": 2,
+                    "options": [
+                        {
+                            "type": "collection",
+                            "name": "AP Physics C: Electrical and Magnetic for Physics Majors",
+                            "required": 1,
+                            "options": [
+                                {
+                                    "type": "collection",
+                                    "name": "AP Physics C: Electrical and Magnetic for Physics Majors",
+                                    "required": 2,
+                                    "options": [
+                                        {
+                                            "type": "major",
+                                            "major": "Physics"
+                                        },
+                                        {
+                                            "type": "course",
+                                            "class_reference": {
+                                                "prefix": "PHYS",
+                                                "number": 3416
+                                            },
+                                            "minimum_grade": "C"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "major",
+                                    "major": "Physics",
+                                    "exclude": true
+                                }
+                            ]
+                        },
+                        {
+                            "type": "exam",
+                            "examReference": {
+                                "$oid": "623f8ef656965e1884291c30"
+                            },
+                            "minimumscore": 5
+                        }
+                    ]
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 2326,
+                            "special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ],
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 4
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c31"
+        },
+        "type": "AP",
+        "name": "General Psychology",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c31"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c31"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c31"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c32"
+        },
+        "type": "AP",
+        "name": "Spanish Language & Culture",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c32"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c32"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c32"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c33"
+        },
+        "type": "AP",
+        "name": "Spanish Literature & Culture",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c33"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c33"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c33"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c34"
+        },
+        "type": "AP",
+        "name": "Statistics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c34"
+                    },
+                    "minimumscore": 3
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "free",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c34"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c34"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c35"
+        },
+        "type": "CLEP",
+        "name": "College French Level 1 (2 semesters)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c35"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c36"
+        },
+        "type": "CLEP",
+        "name": "College Level French Level 2 (4 semesters)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c36"
+                    },
+                    "minimumscore": 58
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c37"
+        },
+        "type": "CLEP",
+        "name": "College German Level 1 (2 semesters)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c37"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c38"
+        },
+        "type": "CLEP",
+        "name": "College Level German Level 2 (4 semesters)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c38"
+                    },
+                    "minimumscore": 58
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GERM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "GERM",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c39"
+        },
+        "type": "CLEP",
+        "name": "College Spanish Level 1 (2 semesters)*",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c39"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c3a"
+        },
+        "type": "CLEP",
+        "name": "College Spanish Level 2 (3 semesters)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c3a"
+                    },
+                    "minimumscore": 60
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c3b"
+        },
+        "type": "CLEP",
+        "name": "College Spanish with Writing (4 semesters)",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c3b"
+                    },
+                    "minimumscore": 65
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c3c"
+        },
+        "type": "CLEP",
+        "name": "American Government",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c3c"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GOVT",
+                            "number": 2305
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c3d"
+        },
+        "type": "CLEP",
+        "name": "American History I: Early Colonization to 1877",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c3d"
+                    },
+                    "minimumscore": 60
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HIST",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c3e"
+        },
+        "type": "CLEP",
+        "name": "American History II: 1865 to Present",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c3e"
+                    },
+                    "minimumscore": 60
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HIST",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c3f"
+        },
+        "type": "CLEP",
+        "name": "Human Growth and Development",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c3f"
+                    },
+                    "minimumscore": 57
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PSY",
+                            "number": 2314
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c40"
+        },
+        "type": "CLEP",
+        "name": "Introduction to Educational Psychology",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c40"
+                    },
+                    "minimumscore": 57
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "Psychology",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c41"
+        },
+        "type": "CLEP",
+        "name": "Introductory Macroeconomics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c41"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c42"
+        },
+        "type": "CLEP",
+        "name": "Introductory Microeconomics",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c42"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c43"
+        },
+        "type": "CLEP",
+        "name": "Introductory Psychology",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c43"
+                    },
+                    "minimumscore": 57
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c44"
+        },
+        "type": "CLEP",
+        "name": "Western Civilization I: Ancient Near East to 1648",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c44"
+                    },
+                    "minimumscore": 60
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HUMA",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c45"
+        },
+        "type": "CLEP",
+        "name": "Western Civilization II: 1648 to Present",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c45"
+                    },
+                    "minimumscore": 60
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "HUMA",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c46"
+        },
+        "type": "CLEP",
+        "name": "Calculus with Elementary Functions",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c46"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c46"
+                    },
+                    "minimumscore": 61
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c47"
+        },
+        "type": "CLEP",
+        "name": "College Algebra",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c47"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c48"
+        },
+        "type": "CLEP",
+        "name": "General Biology",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c48"
+                    },
+                    "minimumscore": 56
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c49"
+        },
+        "type": "CLEP",
+        "name": "General Chemistry",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c49"
+                    },
+                    "minimumscore": 60
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c49"
+                    },
+                    "minimumscore": 70
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c4a"
+        },
+        "type": "CLEP",
+        "name": "Pre-calculus",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4a"
+                    },
+                    "minimumscore": 58
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c4b"
+        },
+        "type": "CLEP",
+        "name": "Information Systems and Computer Applications",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4b"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "Business Computer Information Systems",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c4c"
+        },
+        "type": "IB",
+        "name": "Biology",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4c"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 1300
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4c"
+                    },
+                    "minimumscore": 7
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c4d"
+        },
+        "type": "IB",
+        "name": "Biology",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4d"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 1300
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4d"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "BIOL",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2111
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "BIOL",
+                            "number": 2112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c4e"
+        },
+        "type": "IB",
+        "name": "Chemistry",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4e"
+                    },
+                    "minimumscore": 7
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c4f"
+        },
+        "type": "IB",
+        "name": "Chemistry",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c4f"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHEM",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1111
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "CHEM",
+                            "number": 1112
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c50"
+        },
+        "type": "IB",
+        "name": "Computer Science",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c50"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CS",
+                            "number": 1336
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1136
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c51"
+        },
+        "type": "IB",
+        "name": "Computer Science",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c51"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CS",
+                            "number": 1334
+                        },
+                        {
+                            "prefix": "CS",
+                            "number": 1134
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c52"
+        },
+        "type": "IB",
+        "name": "Economics",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c52"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c53"
+        },
+        "type": "IB",
+        "name": "Economics",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c53"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ECON",
+                            "number": 2301
+                        },
+                        {
+                            "prefix": "ECON",
+                            "number": 2302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c54"
+        },
+        "type": "IB",
+        "name": "Language A: Literature",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c54"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c54"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c55"
+        },
+        "type": "IB",
+        "name": "Language A: Literature",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c55"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c55"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c56"
+        },
+        "type": "IB",
+        "name": "Language A: Language and Literature",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c56"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c56"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c57"
+        },
+        "type": "IB",
+        "name": "Language A: Language and Literature",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c57"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c57"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "RHET",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "LIT",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c58"
+        },
+        "type": "IB",
+        "name": "Environmental Systems and Societies",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c58"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "Geoscience",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c58"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GEOS",
+                            "number": 2302
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c59"
+        },
+        "type": "IB",
+        "name": "Geography",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c59"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "Geography",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c59"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "GEOG",
+                            "number": 2303
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c5a"
+        },
+        "type": "IB",
+        "name": "History (Any Regional Area)",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c5a"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "History",
+                            "credit_hours": 6
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c5b"
+        },
+        "type": "IB",
+        "name": "Any B languange offered by UTD",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c5b"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "category": "Language",
+                            "credit_hours": 3
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c5c"
+        },
+        "type": "IB",
+        "name": "Arabic B",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c5c"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "ARAB",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "ARAB",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c5d"
+        },
+        "type": "IB",
+        "name": "Chinese B",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c5d"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "CHIN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "CHIN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c5e"
+        },
+        "type": "IB",
+        "name": "Frence B",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c5e"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FREN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "FREN",
+                            "number": 1312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c5f"
+        },
+        "type": "IB",
+        "name": "Spanish (A or B)",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c5f"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c60"
+        },
+        "type": "IB",
+        "name": "Spanish (A or B)",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c60"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "SPAN",
+                            "number": 1311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 1312
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2311
+                        },
+                        {
+                            "prefix": "SPAN",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c61"
+        },
+        "type": "IB",
+        "name": "Mathematics",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c61"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c61"
+                    },
+                    "minimumscore": 7
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c62"
+        },
+        "type": "IB",
+        "name": "Mathematics",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c62"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c62"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c63"
+        },
+        "type": "IB",
+        "name": "Mathematics Analysis and Approaches",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c63"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1326
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c63"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c63"
+                    },
+                    "minimumscore": 7
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c64"
+        },
+        "type": "IB",
+        "name": "Mathematics Analysis and Approaches",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c64"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c64"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c65"
+        },
+        "type": "IB",
+        "name": "Mathematics Applications and Interpretations",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c65"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ],
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1316
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c66"
+        },
+        "type": "IB",
+        "name": "Mathematics Applications and Interpretations",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c66"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c67"
+        },
+        "type": "IB",
+        "name": "Further Mathematics",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c67"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2333
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c67"
+                    },
+                    "minimumscore": 7
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2333
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 1342
+                        },
+                        {
+                            "prefix": "STAT",
+                            "number": 2332
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c68"
+        },
+        "type": "IB",
+        "name": "Music",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c68"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MUSI",
+                            "number": 1306
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c69"
+        },
+        "type": "IB",
+        "name": "Music",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c69"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MUSI",
+                            "number": 1306
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c6a"
+        },
+        "type": "IB",
+        "name": "Philosophy",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c6a"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHIL",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c6b"
+        },
+        "type": "IB",
+        "name": "Philosophy",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c6b"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHIL",
+                            "number": 1301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c6c"
+        },
+        "type": "IB",
+        "name": "Physics",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c6c"
+                    },
+                    "minimumscore": 7
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c6d"
+        },
+        "type": "IB",
+        "name": "Physics",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c6d"
+                    },
+                    "minimumscore": 6
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PHYS",
+                            "number": 1301
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2125
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 1302
+                        },
+                        {
+                            "prefix": "PHYS",
+                            "number": 2126
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c6e"
+        },
+        "type": "IB",
+        "name": "Psychology",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c6e"
+                    },
+                    "minimumscore": 5
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "PSY",
+                            "number": 2301
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c6f"
+        },
+        "type": "IB",
+        "name": "Theatre",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c6f"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "THEA",
+                            "number": 1310
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c70"
+        },
+        "type": "IB",
+        "name": "Theatre",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c70"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "THEA",
+                            "number": 1310
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c71"
+        },
+        "type": "IB",
+        "name": "Visual Arts",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c71"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c72"
+        },
+        "type": "IB",
+        "name": "Visual Arts",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c72"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "AHST",
+                            "number": 2331
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c73"
+        },
+        "type": "IB",
+        "name": "Film",
+        "level": "Standard",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c73"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FILM",
+                            "number": 2332
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c74"
+        },
+        "type": "IB",
+        "name": "Film",
+        "level": "Higher",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c74"
+                    },
+                    "minimumscore": 4
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "FILM",
+                            "number": 2332
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "_id": {
+            "$oid": "623f8ef656965e1884291c75"
+        },
+        "type": "ALEKS",
+        "yields": [
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c75"
+                    },
+                    "minimumscore": 35
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1306
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c75"
+                    },
+                    "minimumscore": 50
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1314
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 1316
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c75"
+                    },
+                    "minimumscore": 70
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 1325
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2306
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2312
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c75"
+                    },
+                    "minimumscore": 80
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2370
+                        },
+                        {
+                            "prefix": "MATH",
+                            "number": 2413
+                        }
+                    ]
+                ]
+            },
+            {
+                "requirement": {
+                    "type": "exam",
+                    "examReference": {
+                        "$oid": "623f8ef656965e1884291c75"
+                    },
+                    "minimumscore": 85
+                },
+                "outcome": [
+                    [
+                        {
+                            "prefix": "MATH",
+                            "number": 2417
+                        }
+                    ]
+                ]
+            }
+        ]
+    }
 ]

--- a/scraper/data/ExamsWithoutObjectIds.json
+++ b/scraper/data/ExamsWithoutObjectIds.json
@@ -131,7 +131,10 @@
 				},
 				"outcome": [
 					[
-						"623e0e7981e2c241bf43902e"
+						{
+							"prefix": "ARTS",
+							"number": 1316
+						}
 					]
 				]
 			},
@@ -143,7 +146,10 @@
 				},
 				"outcome": [
 					[
-						"623e0e7981e2c241bf43902e"
+						{
+							"prefix": "ARTS",
+							"number": 1316
+						}
 					]
 				]
 			}
@@ -177,10 +183,22 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad",
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa"
+						{
+							"prefix": "BIOL",
+							"number": 2312
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2112
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2311
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2111
+						}
 					]
 				]
 			},
@@ -192,11 +210,26 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad",
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f5381e2c241bf4390b0"
+						{
+							"prefix": "BIOL",
+							"number": 2312
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2112
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2311
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2111
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2281
+						}
 					]
 				]
 			}
@@ -230,8 +263,14 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197"
+						{
+							"prefix": "CHEM",
+							"number": 1311
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1111
+						}
 					]
 				]
 			},
@@ -243,10 +282,22 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"prefix": "CHEM",
+							"number": 1311
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1111
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1312
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1112
+						}
 					]
 				]
 			}
@@ -344,8 +395,14 @@
 				},
 				"outcome": [
 					[
-						"623e1d098ed6651333148186",
-						"623e1d098ed6651333148188"
+						{
+							"prefix": "CS",
+							"number": 1336
+						},
+						{
+							"prefix": "CS",
+							"number": 1337
+						}
 					]
 				]
 			},
@@ -357,8 +414,14 @@
 				},
 				"outcome": [
 					[
-						"623e1d098ed6651333148186",
-						"623e1d098ed6651333148188"
+						{
+							"prefix": "CS",
+							"number": 1336
+						},
+						{
+							"prefix": "CS",
+							"number": 1337
+						}
 					]
 				]
 			}
@@ -392,7 +455,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"prefix": "ECON",
+							"number": 2301
+						}
 					]
 				]
 			},
@@ -404,7 +470,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"prefix": "ECON",
+							"number": 2301
+						}
 					]
 				]
 			}
@@ -438,7 +507,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3e8ed66513331481de"
+						{
+							"prefix": "ECON",
+							"number": 2302
+						}
 					]
 				]
 			},
@@ -450,7 +522,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3e8ed66513331481de"
+						{
+							"prefix": "ECON",
+							"number": 2302
+						}
 					]
 				]
 			}
@@ -484,7 +559,10 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						}
 					]
 				]
 			},
@@ -496,7 +574,10 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						}
 					]
 				]
 			}
@@ -530,7 +611,10 @@
 				},
 				"outcome": [
 					[
-						"623e38a744e0512c7a91dfaa"
+						{
+							"prefix": "LIT",
+							"number": 2331
+						}
 					]
 				]
 			},
@@ -542,7 +626,10 @@
 				},
 				"outcome": [
 					[
-						"623e38a744e0512c7a91dfaa"
+						{
+							"prefix": "LIT",
+							"number": 2331
+						}
 					]
 				]
 			}
@@ -793,7 +880,10 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"prefix": "GOVT",
+							"number": 2305
+						}
 					]
 				]
 			},
@@ -805,7 +895,10 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"prefix": "GOVT",
+							"number": 2305
+						}
 					]
 				]
 			},
@@ -817,7 +910,10 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"prefix": "GOVT",
+							"number": 2305
+						}
 					]
 				]
 			}
@@ -855,7 +951,10 @@
 							"prefix": "HIST",
 							"number": 1301
 						},
-						"623e382844e0512c7a91df4d"
+						{
+							"prefix": "HIST",
+							"number": 1302
+						}
 					]
 				]
 			},
@@ -871,7 +970,10 @@
 							"prefix": "HIST",
 							"number": 1301
 						},
-						"623e382844e0512c7a91df4d"
+						{
+							"prefix": "HIST",
+							"number": 1302
+						}
 					]
 				]
 			}
@@ -966,7 +1068,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						}
 					]
 				]
 			},
@@ -990,12 +1095,24 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 1325
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2413
+						}
 					]
 				]
 			},
@@ -1019,12 +1136,24 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 1325
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2413
+						}
 					]
 				]
 			}
@@ -1060,12 +1189,24 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 1325
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2413
+						}
 					]
 				]
 			},
@@ -1089,16 +1230,34 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2417
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfba",
-						"623e3a1d44e0512c7a91dfbc"
+						{
+							"prefix": "MATH",
+							"number": 1325
+						},
+						{
+							"prefix": "MATH",
+							"number": 1326
+						}
 					],
 					[
-						"623e3a1e44e0512c7a91dfc0",
-						"623e3a5b44e0512c7a91dfc6"
+						{
+							"prefix": "MATH",
+							"number": 2413
+						},
+						{
+							"prefix": "MATH",
+							"number": 2414
+						}
 					]
 				]
 			},
@@ -1122,16 +1281,34 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2417
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfba",
-						"623e3a1d44e0512c7a91dfbc"
+						{
+							"prefix": "MATH",
+							"number": 1325
+						},
+						{
+							"prefix": "MATH",
+							"number": 1326
+						}
 					],
 					[
-						"623e3a1e44e0512c7a91dfc0",
-						"623e3a5b44e0512c7a91dfc6"
+						{
+							"prefix": "MATH",
+							"number": 2413
+						},
+						{
+							"prefix": "MATH",
+							"number": 2414
+						}
 					]
 				]
 			}
@@ -1217,7 +1394,10 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1233,7 +1413,10 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1271,7 +1454,10 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1287,7 +1473,10 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1325,7 +1514,10 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1341,7 +1533,10 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
 						{
 							"prefix": "PHYS",
 							"number": 1101
@@ -1379,8 +1574,14 @@
 				},
 				"outcome": [
 					[
-						"623e477f44e0512c7a91e0ed",
-						"623e477d44e0512c7a91e0e1"
+						{
+							"prefix": "PHYS",
+							"number": 2325
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2125
+						}
 					]
 				]
 			},
@@ -1392,8 +1593,14 @@
 				},
 				"outcome": [
 					[
-						"623e477f44e0512c7a91e0ed",
-						"623e477d44e0512c7a91e0e1"
+						{
+							"prefix": "PHYS",
+							"number": 2325
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2125
+						}
 					]
 				]
 			}
@@ -1465,8 +1672,15 @@
 				},
 				"outcome": [
 					[
-						"623e478044e0512c7a91e0f1",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"prefix": "PHYS",
+							"number": 2326,
+							"special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2126
+						}
 					],
 					[
 						{
@@ -1522,8 +1736,15 @@
 				},
 				"outcome": [
 					[
-						"623e478044e0512c7a91e0f1",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"prefix": "PHYS",
+							"number": 2326,
+							"special": "Physics Majors: Credit for 2326 + 2126 is applied only if PHYS 3416 is passed with a grade of C or higher; otherwise you earn 4 SCH of free electives."
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2126
+						}
 					],
 					[
 						{
@@ -1563,7 +1784,10 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"prefix": "PSY",
+							"number": 2301
+						}
 					]
 				]
 			},
@@ -1575,7 +1799,10 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"prefix": "PSY",
+							"number": 2301
+						}
 					]
 				]
 			}
@@ -1769,7 +1996,10 @@
 				},
 				"outcome": [
 					[
-						"623e4acee98ae00fbe8a347c"
+						{
+							"prefix": "STAT",
+							"number": 1342
+						}
 					]
 				]
 			},
@@ -1781,7 +2011,10 @@
 				},
 				"outcome": [
 					[
-						"623e4acee98ae00fbe8a347c"
+						{
+							"prefix": "STAT",
+							"number": 1342
+						}
 					]
 				]
 			}
@@ -2010,7 +2243,10 @@
 				},
 				"outcome": [
 					[
-						"623e381944e0512c7a91df3d"
+						{
+							"prefix": "GOVT",
+							"number": 2305
+						}
 					]
 				]
 			}
@@ -2051,7 +2287,10 @@
 				},
 				"outcome": [
 					[
-						"623e382844e0512c7a91df4d"
+						{
+							"prefix": "HIST",
+							"number": 1302
+						}
 					]
 				]
 			}
@@ -2114,7 +2353,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"prefix": "ECON",
+							"number": 2301
+						}
 					]
 				]
 			}
@@ -2133,7 +2375,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3e8ed66513331481de"
+						{
+							"prefix": "ECON",
+							"number": 2302
+						}
 					]
 				]
 			}
@@ -2152,7 +2397,10 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"prefix": "PSY",
+							"number": 2301
+						}
 					]
 				]
 			}
@@ -2215,8 +2463,14 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2413
+						}
 					]
 				]
 			},
@@ -2228,8 +2482,14 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "MATH",
+							"number": 2417
+						}
 					]
 				]
 			}
@@ -2248,7 +2508,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"prefix": "MATH",
+							"number": 1314
+						}
 					]
 				]
 			}
@@ -2267,10 +2530,22 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad"
+						{
+							"prefix": "BIOL",
+							"number": 2311
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2111
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2312
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2112
+						}
 					]
 				]
 			}
@@ -2289,8 +2564,14 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197"
+						{
+							"prefix": "CHEM",
+							"number": 1311
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1111
+						}
 					]
 				]
 			},
@@ -2302,10 +2583,22 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"prefix": "CHEM",
+							"number": 1311
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1111
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1312
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1112
+						}
 					]
 				]
 			}
@@ -2324,7 +2617,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						}
 					]
 				]
 			}
@@ -2381,10 +2677,22 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad"
+						{
+							"prefix": "BIOL",
+							"number": 2311
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2111
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2312
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2112
+						}
 					]
 				]
 			}
@@ -2419,10 +2727,22 @@
 				},
 				"outcome": [
 					[
-						"623e0f9081e2c241bf4390b6",
-						"623e0f5281e2c241bf4390aa",
-						"623e0f9081e2c241bf4390b8",
-						"623e0f5281e2c241bf4390ad"
+						{
+							"prefix": "BIOL",
+							"number": 2311
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2111
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2312
+						},
+						{
+							"prefix": "BIOL",
+							"number": 2112
+						}
 					]
 				]
 			}
@@ -2442,10 +2762,22 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"prefix": "CHEM",
+							"number": 1311
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1111
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1312
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1112
+						}
 					]
 				]
 			}
@@ -2465,10 +2797,22 @@
 				},
 				"outcome": [
 					[
-						"623e19b481e2c241bf43919d",
-						"623e19b381e2c241bf439197",
-						"623e19b481e2c241bf43919f",
-						"623e19b481e2c241bf43919a"
+						{
+							"prefix": "CHEM",
+							"number": 1311
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1111
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1312
+						},
+						{
+							"prefix": "CHEM",
+							"number": 1112
+						}
 					]
 				]
 			}
@@ -2488,8 +2832,14 @@
 				},
 				"outcome": [
 					[
-						"623e1d098ed6651333148186",
-						"623e1d088ed665133314817d"
+						{
+							"prefix": "CS",
+							"number": 1336
+						},
+						{
+							"prefix": "CS",
+							"number": 1136
+						}
 					]
 				]
 			}
@@ -2509,8 +2859,14 @@
 				},
 				"outcome": [
 					[
-						"623e1d088ed6651333148181",
-						"623e1d088ed665133314817b"
+						{
+							"prefix": "CS",
+							"number": 1334
+						},
+						{
+							"prefix": "CS",
+							"number": 1134
+						}
 					]
 				]
 			}
@@ -2530,7 +2886,10 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db"
+						{
+							"prefix": "ECON",
+							"number": 2301
+						}
 					]
 				]
 			}
@@ -2550,8 +2909,14 @@
 				},
 				"outcome": [
 					[
-						"623e1e3c8ed66513331481db",
-						"623e1e3e8ed66513331481de"
+						{
+							"prefix": "ECON",
+							"number": 2301
+						},
+						{
+							"prefix": "ECON",
+							"number": 2302
+						}
 					]
 				]
 			}
@@ -2571,7 +2936,10 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						}
 					]
 				]
 			},
@@ -2583,8 +2951,14 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						},
+						{
+							"prefix": "LIT",
+							"number": 1301
+						}
 					]
 				]
 			}
@@ -2604,7 +2978,10 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						}
 					]
 				]
 			},
@@ -2616,8 +2993,14 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						},
+						{
+							"prefix": "LIT",
+							"number": 1301
+						}
 					]
 				]
 			}
@@ -2637,7 +3020,10 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						}
 					]
 				]
 			},
@@ -2649,8 +3035,14 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						},
+						{
+							"prefix": "LIT",
+							"number": 1301
+						}
 					]
 				]
 			}
@@ -2670,7 +3062,10 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						}
 					]
 				]
 			},
@@ -2682,8 +3077,14 @@
 				},
 				"outcome": [
 					[
-						"623e4aa8e98ae00fbe8a343d",
-						"623e38a744e0512c7a91dfa8"
+						{
+							"prefix": "RHET",
+							"number": 1302
+						},
+						{
+							"prefix": "LIT",
+							"number": 1301
+						}
 					]
 				]
 			}
@@ -2718,7 +3119,10 @@
 				},
 				"outcome": [
 					[
-						"623e380a44e0512c7a91df1b"
+						{
+							"prefix": "GEOS",
+							"number": 2302
+						}
 					]
 				]
 			}
@@ -2969,7 +3373,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						}
 					]
 				]
 			},
@@ -2981,8 +3388,14 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
-						"623e4acee98ae00fbe8a347c"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
+						{
+							"prefix": "STAT",
+							"number": 1342
+						}
 					]
 				]
 			}
@@ -3002,7 +3415,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"prefix": "MATH",
+							"number": 1314
+						}
 					]
 				]
 			},
@@ -3014,9 +3430,18 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba",
-						"623e3a1d44e0512c7a91dfbc",
-						"623e4acee98ae00fbe8a347c"
+						{
+							"prefix": "MATH",
+							"number": 1325
+						},
+						{
+							"prefix": "MATH",
+							"number": 1326
+						},
+						{
+							"prefix": "STAT",
+							"number": 1342
+						}
 					]
 				]
 			}
@@ -3036,10 +3461,16 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"prefix": "MATH",
+							"number": 1325
+						}
 					],
 					[
-						"623e3a1d44e0512c7a91dfbc"
+						{
+							"prefix": "MATH",
+							"number": 1326
+						}
 					]
 				]
 			},
@@ -3051,7 +3482,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1e44e0512c7a91dfc0"
+						{
+							"prefix": "MATH",
+							"number": 2413
+						}
 					]
 				]
 			},
@@ -3063,7 +3497,10 @@
 				},
 				"outcome": [
 					[
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"prefix": "MATH",
+							"number": 2417
+						}
 					]
 				]
 			}
@@ -3083,7 +3520,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"prefix": "MATH",
+							"number": 1314
+						}
 					]
 				]
 			},
@@ -3095,7 +3535,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba"
+						{
+							"prefix": "MATH",
+							"number": 1325
+						}
 					]
 				]
 			}
@@ -3115,7 +3558,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"prefix": "MATH",
+							"number": 1314
+						}
 					],
 					[
 						{
@@ -3141,7 +3587,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8"
+						{
+							"prefix": "MATH",
+							"number": 1314
+						}
 					]
 				]
 			}
@@ -3161,13 +3610,22 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
 						{
 							"prefix": "MATH",
 							"number": 2333
 						},
-						"623e3a1e44e0512c7a91dfc0",
-						"623e4acee98ae00fbe8a347c"
+						{
+							"prefix": "MATH",
+							"number": 2413
+						},
+						{
+							"prefix": "STAT",
+							"number": 1342
+						}
 					]
 				]
 			},
@@ -3179,14 +3637,26 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfbe",
+						{
+							"prefix": "MATH",
+							"number": 2312
+						},
 						{
 							"prefix": "MATH",
 							"number": 2333
 						},
-						"623e3a1e44e0512c7a91dfc0",
-						"623e4acee98ae00fbe8a347c",
-						"623e4acee98ae00fbe8a347e"
+						{
+							"prefix": "MATH",
+							"number": 2413
+						},
+						{
+							"prefix": "STAT",
+							"number": 1342
+						},
+						{
+							"prefix": "STAT",
+							"number": 2332
+						}
 					]
 				]
 			}
@@ -3206,7 +3676,10 @@
 				},
 				"outcome": [
 					[
-						"623e3f3b44e0512c7a91e056"
+						{
+							"prefix": "MUSI",
+							"number": 1306
+						}
 					]
 				]
 			}
@@ -3226,7 +3699,10 @@
 				},
 				"outcome": [
 					[
-						"623e3f3b44e0512c7a91e056"
+						{
+							"prefix": "MUSI",
+							"number": 1306
+						}
 					]
 				]
 			}
@@ -3246,7 +3722,10 @@
 				},
 				"outcome": [
 					[
-						"623e476644e0512c7a91e0d1"
+						{
+							"prefix": "PHIL",
+							"number": 1301
+						}
 					]
 				]
 			}
@@ -3266,7 +3745,10 @@
 				},
 				"outcome": [
 					[
-						"623e476644e0512c7a91e0d1"
+						{
+							"prefix": "PHIL",
+							"number": 1301
+						}
 					]
 				]
 			}
@@ -3286,10 +3768,22 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
-						"623e477d44e0512c7a91e0e1",
-						"623e477c44e0512c7a91e0de",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2125
+						},
+						{
+							"prefix": "PHYS",
+							"number": 1302
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2126
+						}
 					]
 				]
 			}
@@ -3309,10 +3803,22 @@
 				},
 				"outcome": [
 					[
-						"623e477c44e0512c7a91e0dc",
-						"623e477d44e0512c7a91e0e1",
-						"623e477c44e0512c7a91e0de",
-						"623e477e44e0512c7a91e0e6"
+						{
+							"prefix": "PHYS",
+							"number": 1301
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2125
+						},
+						{
+							"prefix": "PHYS",
+							"number": 1302
+						},
+						{
+							"prefix": "PHYS",
+							"number": 2126
+						}
 					]
 				]
 			}
@@ -3332,7 +3838,10 @@
 				},
 				"outcome": [
 					[
-						"623e479344e0512c7a91e0fb"
+						{
+							"prefix": "PSY",
+							"number": 2301
+						}
 					]
 				]
 			}
@@ -3444,7 +3953,10 @@
 				},
 				"outcome": [
 					[
-						"623e27408ed665133314823f"
+						{
+							"prefix": "FILM",
+							"number": 2332
+						}
 					]
 				]
 			}
@@ -3464,7 +3976,10 @@
 				},
 				"outcome": [
 					[
-						"623e27408ed665133314823f"
+						{
+							"prefix": "FILM",
+							"number": 2332
+						}
 					]
 				]
 			}
@@ -3482,7 +3997,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1c44e0512c7a91dfb6"
+						{
+							"prefix": "MATH",
+							"number": 1306
+						}
 					]
 				]
 			},
@@ -3494,7 +4012,10 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfb8",
+						{
+							"prefix": "MATH",
+							"number": 1314
+						},
 						{
 							"prefix": "MATH",
 							"number": 1316
@@ -3510,12 +4031,18 @@
 				},
 				"outcome": [
 					[
-						"623e3a1d44e0512c7a91dfba",
+						{
+							"prefix": "MATH",
+							"number": 1325
+						},
 						{
 							"prefix": "MATH",
 							"number": 2306
 						},
-						"623e3a1d44e0512c7a91dfbe"
+						{
+							"prefix": "MATH",
+							"number": 2312
+						}
 					]
 				]
 			},
@@ -3546,7 +4073,10 @@
 				},
 				"outcome": [
 					[
-						"623e3ad744e0512c7a91dfd2"
+						{
+							"prefix": "MATH",
+							"number": 2417
+						}
 					]
 				]
 			}

--- a/scraper/data/courses.json
+++ b/scraper/data/courses.json
@@ -1,0 +1,20701 @@
+[{
+  "_id": {
+    "$oid": "62410a31e27d0c74c4093da4"
+  },
+  "course_number": "4342",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a27e27d0c74c4093d76"
+  },
+  "course_number": "3200",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a2be27d0c74c4093d88"
+  },
+  "course_number": "3341",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a2ce27d0c74c4093d8e"
+  },
+  "course_number": "3350",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a30e27d0c74c4093d9e"
+  },
+  "course_number": "4337",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a31e27d0c74c4093da2"
+  },
+  "course_number": "4340",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a32e27d0c74c4093da7"
+  },
+  "course_number": "4V80",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a39e27d0c74c4093dc6"
+  },
+  "course_number": "6320",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a3ee27d0c74c4093dda"
+  },
+  "course_number": "6334",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a43e27d0c74c4093df2"
+  },
+  "course_number": "6343",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a48e27d0c74c4093e0a"
+  },
+  "course_number": "6370",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a67e27d0c74c4093e14"
+  },
+  "course_number": "6380",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a6de27d0c74c4093e18"
+  },
+  "course_number": "6383",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a9fe27d0c74c4093e26"
+  },
+  "course_number": "7344",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b5ce27d0c74c4093e38"
+  },
+  "course_number": "6374",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b67e27d0c74c4093e3d"
+  },
+  "course_number": "6395",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410ddbe27d0c74c4093e6e"
+  },
+  "course_number": "2390",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62410de5e27d0c74c4093e77"
+  },
+  "course_number": "4304",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62410df3e27d0c74c4093e7d"
+  },
+  "course_number": "4385",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62410efde27d0c74c4093e8b"
+  },
+  "course_number": "2344",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "62411006e27d0c74c4093e96"
+  },
+  "course_number": "1301",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411009e27d0c74c4093ea4"
+  },
+  "course_number": "2315",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c4e27d0c74c4093ec3"
+  },
+  "course_number": "3369",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c8e27d0c74c4093ed6"
+  },
+  "course_number": "3379",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411794e27d0c74c4093f43"
+  },
+  "course_number": "3305",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411799e27d0c74c4093f56"
+  },
+  "course_number": "3311",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411799e27d0c74c4093f5a"
+  },
+  "course_number": "3321",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a0e27d0c74c4093f7a"
+  },
+  "course_number": "3365",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187ce27d0c74c4093fbe"
+  },
+  "course_number": "4366",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187de27d0c74c4093fc2"
+  },
+  "course_number": "4376",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411880e27d0c74c4093fd0"
+  },
+  "course_number": "6300",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a34e27d0c74c4093db3"
+  },
+  "course_number": "6305",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a21e27d0c74c4093d5a"
+  },
+  "course_number": "2301",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a32e27d0c74c4093daa"
+  },
+  "course_number": "6201",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a3de27d0c74c4093dd6"
+  },
+  "course_number": "6333",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a44e27d0c74c4093df8"
+  },
+  "course_number": "6345",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a45e27d0c74c4093dfa"
+  },
+  "course_number": "6349",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b39e27d0c74c4093e36"
+  },
+  "course_number": "6349",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410be5e27d0c74c4093e43"
+  },
+  "course_number": "4302",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410e6fe27d0c74c4093e7f"
+  },
+  "course_number": "1311",
+  "subject_prefix": "ARAB"
+},{
+  "_id": {
+    "$oid": "62411082e27d0c74c4093ea6"
+  },
+  "course_number": "2316",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c5e27d0c74c4093ec5"
+  },
+  "course_number": "3371",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c7e27d0c74c4093ed2"
+  },
+  "course_number": "3376",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411795e27d0c74c4093f46"
+  },
+  "course_number": "3306",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411799e27d0c74c4093f58"
+  },
+  "course_number": "3320",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ee27d0c74c4093f70"
+  },
+  "course_number": "3346",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a1e27d0c74c4093f7f"
+  },
+  "course_number": "3366",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241182be27d0c74c4093fa0"
+  },
+  "course_number": "4305",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241183de27d0c74c4093fb2"
+  },
+  "course_number": "4337",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411869e27d0c74c4093fb8"
+  },
+  "course_number": "4365",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411883e27d0c74c4093fe2"
+  },
+  "course_number": "6341",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a37e27d0c74c4093dbd"
+  },
+  "course_number": "6309",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a73e27d0c74c4093e1d"
+  },
+  "course_number": "6388",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a9fe27d0c74c4093e22"
+  },
+  "course_number": "7313",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a9fe27d0c74c4093e24"
+  },
+  "course_number": "7323",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b2fe27d0c74c4093e30"
+  },
+  "course_number": "6340",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b36e27d0c74c4093e34"
+  },
+  "course_number": "6346",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b60e27d0c74c4093e3b"
+  },
+  "course_number": "6389",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410d50e27d0c74c4093e65"
+  },
+  "course_number": "2331",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "62410de2e27d0c74c4093e74"
+  },
+  "course_number": "4300",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62410df0e27d0c74c4093e7b"
+  },
+  "course_number": "4327",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62411790e27d0c74c4093f2b"
+  },
+  "course_number": "2320",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411791e27d0c74c4093f33"
+  },
+  "course_number": "2355",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ce27d0c74c4093f69"
+  },
+  "course_number": "3340",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ee27d0c74c4093f73"
+  },
+  "course_number": "3350",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117f0e27d0c74c4093f97"
+  },
+  "course_number": "3388",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117f7e27d0c74c4093f9a"
+  },
+  "course_number": "3395",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411838e27d0c74c4093fa4"
+  },
+  "course_number": "4308",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187ee27d0c74c4093fc6"
+  },
+  "course_number": "4380",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411880e27d0c74c4093fd4"
+  },
+  "course_number": "6305",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a30e27d0c74c4093d9b"
+  },
+  "course_number": "4336",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a25e27d0c74c4093d6e"
+  },
+  "course_number": "2302",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a2ee27d0c74c4093d96"
+  },
+  "course_number": "4334",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a3be27d0c74c4093dcd"
+  },
+  "course_number": "6330",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a3ce27d0c74c4093dd4"
+  },
+  "course_number": "6332",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a3fe27d0c74c4093dde"
+  },
+  "course_number": "6335",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a43e27d0c74c4093df4"
+  },
+  "course_number": "6344",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a47e27d0c74c4093e07"
+  },
+  "course_number": "6365",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b1ee27d0c74c4093e28"
+  },
+  "course_number": "6312",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410befe27d0c74c4093e49"
+  },
+  "course_number": "6304",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410c90e27d0c74c4093e54"
+  },
+  "course_number": "2030",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410c9de27d0c74c4093e59"
+  },
+  "course_number": "3310",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410dd5e27d0c74c4093e6b"
+  },
+  "course_number": "2341",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62410ddde27d0c74c4093e71"
+  },
+  "course_number": "3316",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "624110c2e27d0c74c4093eb7"
+  },
+  "course_number": "3341",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c8e27d0c74c4093ed4"
+  },
+  "course_number": "3377",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411787e27d0c74c4093f0d"
+  },
+  "course_number": "2301",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411792e27d0c74c4093f38"
+  },
+  "course_number": "2380",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411798e27d0c74c4093f53"
+  },
+  "course_number": "3310",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179be27d0c74c4093f62"
+  },
+  "course_number": "3337",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117c9e27d0c74c4093f94"
+  },
+  "course_number": "3385",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187de27d0c74c4093fc0"
+  },
+  "course_number": "4367",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411882e27d0c74c4093fdc"
+  },
+  "course_number": "6323",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a2ae27d0c74c4093d85"
+  },
+  "course_number": "3332",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a2ee27d0c74c4093d94"
+  },
+  "course_number": "4301",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a33e27d0c74c4093dac"
+  },
+  "course_number": "6202",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a3ce27d0c74c4093dd2"
+  },
+  "course_number": "6331",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a46e27d0c74c4093dff"
+  },
+  "course_number": "6353",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a47e27d0c74c4093e03"
+  },
+  "course_number": "6354",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a63e27d0c74c4093e12"
+  },
+  "course_number": "6377",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b29e27d0c74c4093e2c"
+  },
+  "course_number": "6330",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b2be27d0c74c4093e2e"
+  },
+  "course_number": "6338",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410bf2e27d0c74c4093e4b"
+  },
+  "course_number": "6306",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410c84e27d0c74c4093e4f"
+  },
+  "course_number": "1030",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410f04e27d0c74c4093e8f"
+  },
+  "course_number": "2V71",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "62410f07e27d0c74c4093e91"
+  },
+  "course_number": "3342",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "62411007e27d0c74c4093e9b"
+  },
+  "course_number": "1316",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c1e27d0c74c4093eb1"
+  },
+  "course_number": "2381",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c4e27d0c74c4093ec1"
+  },
+  "course_number": "3368",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411790e27d0c74c4093f2d"
+  },
+  "course_number": "2345",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ae27d0c74c4093f5c"
+  },
+  "course_number": "3330",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a2e27d0c74c4093f86"
+  },
+  "course_number": "3368",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a3e27d0c74c4093f8c"
+  },
+  "course_number": "3370",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411839e27d0c74c4093fa8"
+  },
+  "course_number": "4312",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241183ce27d0c74c4093fad"
+  },
+  "course_number": "4326",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411881e27d0c74c4093fd8"
+  },
+  "course_number": "6321",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411882e27d0c74c4093fde"
+  },
+  "course_number": "6325",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a6ae27d0c74c4093e16"
+  },
+  "course_number": "6382",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b69e27d0c74c4093e41"
+  },
+  "course_number": "7324",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410cc6e27d0c74c4093e5d"
+  },
+  "course_number": "4310",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410d52e27d0c74c4093e67"
+  },
+  "course_number": "3315",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "62410ef2e27d0c74c4093e85"
+  },
+  "course_number": "1100",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "624110c2e27d0c74c4093eb3"
+  },
+  "course_number": "3340",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c5e27d0c74c4093ec9"
+  },
+  "course_number": "3372",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c7e27d0c74c4093ece"
+  },
+  "course_number": "3373",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "6241177ce27d0c74c4093eea"
+  },
+  "course_number": "1100",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241178be27d0c74c4093f19"
+  },
+  "course_number": "2302",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411792e27d0c74c4093f3a"
+  },
+  "course_number": "3301",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411796e27d0c74c4093f4b"
+  },
+  "course_number": "3307",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ee27d0c74c4093f6e"
+  },
+  "course_number": "3345",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a2e27d0c74c4093f8a"
+  },
+  "course_number": "3369",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411831e27d0c74c4093fa2"
+  },
+  "course_number": "4306",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187de27d0c74c4093fc4"
+  },
+  "course_number": "4379",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187fe27d0c74c4093fce"
+  },
+  "course_number": "6000",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411880e27d0c74c4093fd2"
+  },
+  "course_number": "6304",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411881e27d0c74c4093fd6"
+  },
+  "course_number": "6312",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411881e27d0c74c4093fda"
+  },
+  "course_number": "6322",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a29e27d0c74c4093d7f"
+  },
+  "course_number": "3331",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a33e27d0c74c4093daf"
+  },
+  "course_number": "6301",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a40e27d0c74c4093de4"
+  },
+  "course_number": "6338",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a71e27d0c74c4093e1b"
+  },
+  "course_number": "6386",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410be8e27d0c74c4093e45"
+  },
+  "course_number": "4308",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410bece27d0c74c4093e47"
+  },
+  "course_number": "6301",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410bf5e27d0c74c4093e4d"
+  },
+  "course_number": "6308",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410d55e27d0c74c4093e69"
+  },
+  "course_number": "3319",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "624110c9e27d0c74c4093edb"
+  },
+  "course_number": "4368",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411782e27d0c74c4093efe"
+  },
+  "course_number": "2300",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241178fe27d0c74c4093f28"
+  },
+  "course_number": "2305",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411798e27d0c74c4093f51"
+  },
+  "course_number": "3309",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ae27d0c74c4093f5f"
+  },
+  "course_number": "3335",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a1e27d0c74c4093f82"
+  },
+  "course_number": "3367",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a4e27d0c74c4093f92"
+  },
+  "course_number": "3376",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411839e27d0c74c4093fa6"
+  },
+  "course_number": "4310",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411882e27d0c74c4093fe0"
+  },
+  "course_number": "6336",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62410a40e27d0c74c4093de1"
+  },
+  "course_number": "6336",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a40e27d0c74c4093de7"
+  },
+  "course_number": "6340",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a45e27d0c74c4093dfd"
+  },
+  "course_number": "6350",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a47e27d0c74c4093e05"
+  },
+  "course_number": "6356",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a48e27d0c74c4093e0d"
+  },
+  "course_number": "6373",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b32e27d0c74c4093e32"
+  },
+  "course_number": "6341",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410d49e27d0c74c4093e61"
+  },
+  "course_number": "1304",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "62410de7e27d0c74c4093e79"
+  },
+  "course_number": "4305",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "62410e72e27d0c74c4093e81"
+  },
+  "course_number": "1312",
+  "subject_prefix": "ARAB"
+},{
+  "_id": {
+    "$oid": "62410e75e27d0c74c4093e83"
+  },
+  "course_number": "2312",
+  "subject_prefix": "ARAB"
+},{
+  "_id": {
+    "$oid": "6241108fe27d0c74c4093ea9"
+  },
+  "course_number": "2350",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110bee27d0c74c4093eac"
+  },
+  "course_number": "2380",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c3e27d0c74c4093eba"
+  },
+  "course_number": "3363",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c3e27d0c74c4093ebc"
+  },
+  "course_number": "3366",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c3e27d0c74c4093ebf"
+  },
+  "course_number": "3367",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c7e27d0c74c4093ed0"
+  },
+  "course_number": "3375",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624110c9e27d0c74c4093ed9"
+  },
+  "course_number": "4308",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "6241178ee27d0c74c4093f23"
+  },
+  "course_number": "2303",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411792e27d0c74c4093f35"
+  },
+  "course_number": "2365",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411797e27d0c74c4093f4e"
+  },
+  "course_number": "3308",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241179ce27d0c74c4093f66"
+  },
+  "course_number": "3338",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624117a4e27d0c74c4093f8f"
+  },
+  "course_number": "3371",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241183be27d0c74c4093faa"
+  },
+  "course_number": "4319",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241183de27d0c74c4093fb0"
+  },
+  "course_number": "4330",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241183de27d0c74c4093fb4"
+  },
+  "course_number": "4346",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411841e27d0c74c4093fb6"
+  },
+  "course_number": "4350",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241187ee27d0c74c4093fc8"
+  },
+  "course_number": "4395",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411885e27d0c74c4093ff1"
+  },
+  "course_number": "6390",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411884e27d0c74c4093feb"
+  },
+  "course_number": "6365",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411884e27d0c74c4093fe9"
+  },
+  "course_number": "6355",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411886e27d0c74c4093ff5"
+  },
+  "course_number": "6395",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411a5be27d0c74c4094030"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "624122b0e27d0c74c409407a"
+  },
+  "course_number": "1V00",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122bee27d0c74c40940a5"
+  },
+  "course_number": "2350",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cbe27d0c74c40940d3"
+  },
+  "course_number": "3302",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cce27d0c74c40940d8"
+  },
+  "course_number": "3318",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cee27d0c74c40940e0"
+  },
+  "course_number": "3361",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412391e27d0c74c4094116"
+  },
+  "course_number": "4360",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412396e27d0c74c4094129"
+  },
+  "course_number": "5460",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412396e27d0c74c409412b"
+  },
+  "course_number": "5V01",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241243de27d0c74c4094153"
+  },
+  "course_number": "3320",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "624126b1e27d0c74c4094176"
+  },
+  "course_number": "1100",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624126b5e27d0c74c4094182"
+  },
+  "course_number": "1208",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127e9e27d0c74c4094196"
+  },
+  "course_number": "3315",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f2e27d0c74c40941a4"
+  },
+  "course_number": "3370",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f3e27d0c74c40941a8"
+  },
+  "course_number": "3399",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f8e27d0c74c40941bd"
+  },
+  "course_number": "4360",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127fee27d0c74c40941d6"
+  },
+  "course_number": "6345",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127ffe27d0c74c40941dd"
+  },
+  "course_number": "6373",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127ffe27d0c74c40941e0"
+  },
+  "course_number": "6374",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412800e27d0c74c40941e2"
+  },
+  "course_number": "6377",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c98e27d0c74c409423b"
+  },
+  "course_number": "6337",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412c9de27d0c74c4094254"
+  },
+  "course_number": "6356",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62413290e27d0c74c40942ec"
+  },
+  "course_number": "2310",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624119dee27d0c74c4094010"
+  },
+  "course_number": "1100",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "62411b61e27d0c74c4094033"
+  },
+  "course_number": "3100",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "62411b64e27d0c74c4094042"
+  },
+  "course_number": "3310",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "624122c1e27d0c74c40940b0"
+  },
+  "course_number": "3102",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122d3e27d0c74c40940f0"
+  },
+  "course_number": "3388",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412390e27d0c74c409410f"
+  },
+  "course_number": "4315",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412435e27d0c74c409414c"
+  },
+  "course_number": "3190",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "624127e9e27d0c74c4094194"
+  },
+  "course_number": "3130",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412801e27d0c74c40941e8"
+  },
+  "course_number": "6393",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c9ae27d0c74c4094248"
+  },
+  "course_number": "6345",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412ca0e27d0c74c4094261"
+  },
+  "course_number": "6390",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "6241190ce27d0c74c4093ffb"
+  },
+  "course_number": "6303",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411916e27d0c74c4094002"
+  },
+  "course_number": "6V20",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "624122b0e27d0c74c409407c"
+  },
+  "course_number": "2111",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cee27d0c74c40940de"
+  },
+  "course_number": "3357",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122d3e27d0c74c40940f2"
+  },
+  "course_number": "3455",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412385e27d0c74c4094104"
+  },
+  "course_number": "3V00",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412390e27d0c74c409410b"
+  },
+  "course_number": "3V83",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412392e27d0c74c4094118"
+  },
+  "course_number": "4380",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412399e27d0c74c409413a"
+  },
+  "course_number": "6354",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241239ae27d0c74c4094142"
+  },
+  "course_number": "6V49",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241252de27d0c74c409416a"
+  },
+  "course_number": "2301",
+  "subject_prefix": "BLAW"
+},{
+  "_id": {
+    "$oid": "624127ace27d0c74c409418b"
+  },
+  "course_number": "3120",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127eae27d0c74c4094199"
+  },
+  "course_number": "3320",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f2e27d0c74c40941a6"
+  },
+  "course_number": "3380",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f6e27d0c74c40941b2"
+  },
+  "course_number": "4310",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f7e27d0c74c40941b9"
+  },
+  "course_number": "4342",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127fde27d0c74c40941d2"
+  },
+  "course_number": "6331",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127fee27d0c74c40941d8"
+  },
+  "course_number": "6351",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127ffe27d0c74c40941db"
+  },
+  "course_number": "6365",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412803e27d0c74c40941ef"
+  },
+  "course_number": "7188",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412803e27d0c74c40941f1"
+  },
+  "course_number": "7341",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c95e27d0c74c4094231"
+  },
+  "course_number": "6324",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412c9be27d0c74c409424d"
+  },
+  "course_number": "6346",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "6241191ae27d0c74c4094005"
+  },
+  "course_number": "7240",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241191de27d0c74c4094007"
+  },
+  "course_number": "7310",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411948e27d0c74c409400e"
+  },
+  "course_number": "7338",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411a59e27d0c74c4094027"
+  },
+  "course_number": "3200",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "624122b0e27d0c74c4094078"
+  },
+  "course_number": "1318",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122b5e27d0c74c409408b"
+  },
+  "course_number": "2112",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122b7e27d0c74c4094092"
+  },
+  "course_number": "2281",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122c9e27d0c74c40940ca"
+  },
+  "course_number": "3162",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cbe27d0c74c40940d1"
+  },
+  "course_number": "3301",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cde27d0c74c40940da"
+  },
+  "course_number": "3320",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241238fe27d0c74c4094109"
+  },
+  "course_number": "3V15",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412391e27d0c74c4094114"
+  },
+  "course_number": "4356",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412395e27d0c74c4094127"
+  },
+  "course_number": "5420",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241239ae27d0c74c409413e"
+  },
+  "course_number": "6373",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624124a2e27d0c74c4094162"
+  },
+  "course_number": "4V04",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "62412545e27d0c74c4094173"
+  },
+  "course_number": "3301",
+  "subject_prefix": "BLAW"
+},{
+  "_id": {
+    "$oid": "624127f3e27d0c74c40941aa"
+  },
+  "course_number": "4110",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127fce27d0c74c40941ca"
+  },
+  "course_number": "4389",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127fce27d0c74c40941cd"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127fde27d0c74c40941cf"
+  },
+  "course_number": "6201",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c93e27d0c74c409422b"
+  },
+  "course_number": "6320",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412c98e27d0c74c4094239"
+  },
+  "course_number": "6335",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62413289e27d0c74c40942d8"
+  },
+  "course_number": "1202",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6241328ce27d0c74c40942e3"
+  },
+  "course_number": "2305",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62413293e27d0c74c40942f6"
+  },
+  "course_number": "3101",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62411883e27d0c74c4093fe4"
+  },
+  "course_number": "6343",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411886e27d0c74c4093ff7"
+  },
+  "course_number": "7331",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241190fe27d0c74c4093ffd"
+  },
+  "course_number": "6305",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411c18e27d0c74c409405b"
+  },
+  "course_number": "4350",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "624122bce27d0c74c409409f"
+  },
+  "course_number": "2311",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122bde27d0c74c40940a3"
+  },
+  "course_number": "2312",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122bee27d0c74c40940a8"
+  },
+  "course_number": "3101",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122c4e27d0c74c40940ba"
+  },
+  "course_number": "3161",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122cfe27d0c74c40940e5"
+  },
+  "course_number": "3380",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412390e27d0c74c409410d"
+  },
+  "course_number": "4302",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412395e27d0c74c4094123"
+  },
+  "course_number": "5375",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412398e27d0c74c4094133"
+  },
+  "course_number": "6252",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412399e27d0c74c409413c"
+  },
+  "course_number": "6356",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624127f6e27d0c74c40941b6"
+  },
+  "course_number": "4320",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c92e27d0c74c4094227"
+  },
+  "course_number": "6312",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412c99e27d0c74c409423f"
+  },
+  "course_number": "6340",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412c99e27d0c74c4094243"
+  },
+  "course_number": "6341",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62413299e27d0c74c4094306"
+  },
+  "course_number": "3110",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62411907e27d0c74c4093ff9"
+  },
+  "course_number": "6113",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411885e27d0c74c4093fef"
+  },
+  "course_number": "6377",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411b62e27d0c74c409403c"
+  },
+  "course_number": "3200",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "624122cde27d0c74c40940dc"
+  },
+  "course_number": "3335",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122d7e27d0c74c40940fc"
+  },
+  "course_number": "3456",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412394e27d0c74c4094120"
+  },
+  "course_number": "4V00",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412395e27d0c74c4094125"
+  },
+  "course_number": "5376",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412398e27d0c74c4094131"
+  },
+  "course_number": "6193",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412398e27d0c74c4094136"
+  },
+  "course_number": "6333",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624124a0e27d0c74c409415a"
+  },
+  "course_number": "4306",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "624127ebe27d0c74c409419c"
+  },
+  "course_number": "3325",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624127f8e27d0c74c40941bf"
+  },
+  "course_number": "4388",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412801e27d0c74c40941ea"
+  },
+  "course_number": "6V87",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412803e27d0c74c40941f3"
+  },
+  "course_number": "8V70",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412882e27d0c74c40941f5"
+  },
+  "course_number": "4305",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "624128dae27d0c74c4094210"
+  },
+  "course_number": "7302",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "624128dae27d0c74c4094212"
+  },
+  "course_number": "7307",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "62412c9fe27d0c74c409425c"
+  },
+  "course_number": "6357",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62412ca2e27d0c74c409426a"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62413290e27d0c74c40942ef"
+  },
+  "course_number": "2336",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62411911e27d0c74c4094000"
+  },
+  "course_number": "6310",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411921e27d0c74c409400a"
+  },
+  "course_number": "7324",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "624122cce27d0c74c40940d6"
+  },
+  "course_number": "3303",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412397e27d0c74c409412e"
+  },
+  "course_number": "5V95",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412399e27d0c74c4094138"
+  },
+  "course_number": "6352",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241239ae27d0c74c4094140"
+  },
+  "course_number": "6V00",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624127f1e27d0c74c409419f"
+  },
+  "course_number": "3330",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412800e27d0c74c40941e4"
+  },
+  "course_number": "6387",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412800e27d0c74c40941e6"
+  },
+  "course_number": "6391",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624128c9e27d0c74c4094209"
+  },
+  "course_number": "6310",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "62413289e27d0c74c40942da"
+  },
+  "course_number": "1337",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62411884e27d0c74c4093fe6"
+  },
+  "course_number": "6349",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411885e27d0c74c4093fed"
+  },
+  "course_number": "6375",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411886e27d0c74c4093ff3"
+  },
+  "course_number": "6392",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62411945e27d0c74c409400c"
+  },
+  "course_number": "7327",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411a5be27d0c74c409402d"
+  },
+  "course_number": "4101",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "624122cfe27d0c74c40940e3"
+  },
+  "course_number": "3362",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412391e27d0c74c4094112"
+  },
+  "course_number": "4350",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412394e27d0c74c409411e"
+  },
+  "course_number": "4385",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412434e27d0c74c4094145"
+  },
+  "course_number": "1100",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "624124a1e27d0c74c409415d"
+  },
+  "course_number": "4310",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "624124a1e27d0c74c4094160"
+  },
+  "course_number": "4V02",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "62412772e27d0c74c4094185"
+  },
+  "course_number": "2320",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624128d0e27d0c74c409420c"
+  },
+  "course_number": "6332",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "624128dae27d0c74c409420e"
+  },
+  "course_number": "6360",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "62412ca0e27d0c74c4094263"
+  },
+  "course_number": "6398",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62413295e27d0c74c40942fc"
+  },
+  "course_number": "3102",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132a1e27d0c74c409431c"
+  },
+  "course_number": "3302",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132a4e27d0c74c4094329"
+  },
+  "course_number": "3345",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132b1e27d0c74c409435d"
+  },
+  "course_number": "8V40",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624133c4e27d0c74c4094375"
+  },
+  "course_number": "4314",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624133c4e27d0c74c4094377"
+  },
+  "course_number": "4352",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62413397e27d0c74c4094371"
+  },
+  "course_number": "3361",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624135dae27d0c74c4094385"
+  },
+  "course_number": "1111",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413816e27d0c74c4094425"
+  },
+  "course_number": "6361",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413817e27d0c74c4094429"
+  },
+  "course_number": "6V59",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624137fde27d0c74c40943cf"
+  },
+  "course_number": "1315",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241392ce27d0c74c4094439"
+  },
+  "course_number": "3303",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "624137fde27d0c74c40943d1"
+  },
+  "course_number": "2123",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413979e27d0c74c409444e"
+  },
+  "course_number": "4308",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241380de27d0c74c4094401"
+  },
+  "course_number": "2327",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62414011e27d0c74c409449d"
+  },
+  "course_number": "1315",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6241380ee27d0c74c4094403"
+  },
+  "course_number": "2330",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62414077e27d0c74c40944ad"
+  },
+  "course_number": "1307",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62413815e27d0c74c4094420"
+  },
+  "course_number": "5341",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62414079e27d0c74c40944b9"
+  },
+  "course_number": "2317",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62413816e27d0c74c4094423"
+  },
+  "course_number": "6100",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241407ae27d0c74c40944c1"
+  },
+  "course_number": "3302",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62413896e27d0c74c409442b"
+  },
+  "course_number": "1301",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "6241407be27d0c74c40944c7"
+  },
+  "course_number": "3310",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62413930e27d0c74c409443b"
+  },
+  "course_number": "3310",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241407de27d0c74c40944d3"
+  },
+  "course_number": "4311",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414011e27d0c74c40944a1"
+  },
+  "course_number": "3342",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "62414081e27d0c74c40944eb"
+  },
+  "course_number": "7305",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414012e27d0c74c40944a8"
+  },
+  "course_number": "4375",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6241407ae27d0c74c40944be"
+  },
+  "course_number": "3301",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414c41e27d0c74c4094558"
+  },
+  "course_number": "1325",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241407be27d0c74c40944ca"
+  },
+  "course_number": "3319",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414c42e27d0c74c409455b"
+  },
+  "course_number": "1334",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624132a3e27d0c74c4094323"
+  },
+  "course_number": "3311",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132a9e27d0c74c4094336"
+  },
+  "course_number": "4304",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132b1e27d0c74c409435b"
+  },
+  "course_number": "6370",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132c3e27d0c74c409435f"
+  },
+  "course_number": "8V70",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62413349e27d0c74c4094361"
+  },
+  "course_number": "2301",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624133c6e27d0c74c409437f"
+  },
+  "course_number": "4386",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62413809e27d0c74c40943f4"
+  },
+  "course_number": "2130",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241380de27d0c74c40943fe"
+  },
+  "course_number": "2325",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624138a2e27d0c74c4094433"
+  },
+  "course_number": "2311",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "624138a5e27d0c74c4094435"
+  },
+  "course_number": "3365",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "62413938e27d0c74c4094440"
+  },
+  "course_number": "3332",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "62413943e27d0c74c4094446"
+  },
+  "course_number": "3342",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241397de27d0c74c4094458"
+  },
+  "course_number": "4395",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "62414005e27d0c74c4094473"
+  },
+  "course_number": "1311",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "62414012e27d0c74c40944a5"
+  },
+  "course_number": "4314",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "62414077e27d0c74c40944ab"
+  },
+  "course_number": "1301",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414079e27d0c74c40944bc"
+  },
+  "course_number": "3300",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407ce27d0c74c40944cc"
+  },
+  "course_number": "3323",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407ee27d0c74c40944da"
+  },
+  "course_number": "4396",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407ee27d0c74c40944dd"
+  },
+  "course_number": "6300",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624140abe27d0c74c40944f7"
+  },
+  "course_number": "3307",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "624140e1e27d0c74c4094502"
+  },
+  "course_number": "4353",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62414c43e27d0c74c4094562"
+  },
+  "course_number": "1336",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c52e27d0c74c409458d"
+  },
+  "course_number": "2336",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eade27d0c74c40945dd"
+  },
+  "course_number": "4337",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241329be27d0c74c409430c"
+  },
+  "course_number": "3111",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132a2e27d0c74c4094320"
+  },
+  "course_number": "3310",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132ace27d0c74c4094344"
+  },
+  "course_number": "4389",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132b0e27d0c74c4094358"
+  },
+  "course_number": "6325",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624133c6e27d0c74c4094381"
+  },
+  "course_number": "4394",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62413807e27d0c74c40943ed"
+  },
+  "course_number": "2125",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413810e27d0c74c409440a"
+  },
+  "course_number": "3321",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413812e27d0c74c4094412"
+  },
+  "course_number": "3362",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241389fe27d0c74c4094431"
+  },
+  "course_number": "1312",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "62414012e27d0c74c40944a3"
+  },
+  "course_number": "3351",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "62414078e27d0c74c40944b4"
+  },
+  "course_number": "2313",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414079e27d0c74c40944b7"
+  },
+  "course_number": "2316",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414c43e27d0c74c409455f"
+  },
+  "course_number": "1335",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c55e27d0c74c4094595"
+  },
+  "course_number": "3162",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c57e27d0c74c409459d"
+  },
+  "course_number": "3305",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ea2e27d0c74c40945be"
+  },
+  "course_number": "3360",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eace27d0c74c40945d6"
+  },
+  "course_number": "4314",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eade27d0c74c40945d8"
+  },
+  "course_number": "4332",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eafe27d0c74c40945e2"
+  },
+  "course_number": "4341",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241329de27d0c74c4094311"
+  },
+  "course_number": "3120",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132a6e27d0c74c409432f"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132a0e27d0c74c4094319"
+  },
+  "course_number": "3301",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132abe27d0c74c409433e"
+  },
+  "course_number": "4348",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132aee27d0c74c409434e"
+  },
+  "course_number": "6304",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132afe27d0c74c4094353"
+  },
+  "course_number": "6306",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624133c6e27d0c74c4094383"
+  },
+  "course_number": "4395",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624137f6e27d0c74c40943c2"
+  },
+  "course_number": "1311",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241380ee27d0c74c4094405"
+  },
+  "course_number": "2401",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413816e27d0c74c4094427"
+  },
+  "course_number": "6389",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241389ae27d0c74c409442d"
+  },
+  "course_number": "1311",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "6241407de27d0c74c40944d6"
+  },
+  "course_number": "4315",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407fe27d0c74c40944df"
+  },
+  "course_number": "6301",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407fe27d0c74c40944e1"
+  },
+  "course_number": "6303",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414080e27d0c74c40944e5"
+  },
+  "course_number": "7300",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624140e4e27d0c74c4094504"
+  },
+  "course_number": "4354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62414c3ae27d0c74c4094545"
+  },
+  "course_number": "1200",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eabe27d0c74c40945d3"
+  },
+  "course_number": "4301",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624132abe27d0c74c4094340"
+  },
+  "course_number": "4388",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132ade27d0c74c4094347"
+  },
+  "course_number": "4390",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132aee27d0c74c409434a"
+  },
+  "course_number": "5325",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624133c5e27d0c74c409437d"
+  },
+  "course_number": "4385",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624137f5e27d0c74c40943bd"
+  },
+  "course_number": "1115",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624137f5e27d0c74c40943bf"
+  },
+  "course_number": "1301",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624137fce27d0c74c40943cc"
+  },
+  "course_number": "1312",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413810e27d0c74c409440d"
+  },
+  "course_number": "3341",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413811e27d0c74c409440f"
+  },
+  "course_number": "3361",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413812e27d0c74c4094414"
+  },
+  "course_number": "3471",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413813e27d0c74c4094417"
+  },
+  "course_number": "3472",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413814e27d0c74c409441b"
+  },
+  "course_number": "4390",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413815e27d0c74c409441e"
+  },
+  "course_number": "5331",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241392ae27d0c74c4094437"
+  },
+  "course_number": "2314",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "62413973e27d0c74c409444c"
+  },
+  "course_number": "3394",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241397ce27d0c74c4094451"
+  },
+  "course_number": "4344",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241397de27d0c74c4094454"
+  },
+  "course_number": "4347",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "62414078e27d0c74c40944b1"
+  },
+  "course_number": "2308",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414080e27d0c74c40944e8"
+  },
+  "course_number": "7301",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414081e27d0c74c40944ed"
+  },
+  "course_number": "7381",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624140a9e27d0c74c40944ef"
+  },
+  "course_number": "2301",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "624140dce27d0c74c4094500"
+  },
+  "course_number": "4307",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62414c40e27d0c74c4094556"
+  },
+  "course_number": "1324",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c52e27d0c74c409458a"
+  },
+  "course_number": "2335",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c5be27d0c74c40945aa"
+  },
+  "course_number": "3341",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624132a4e27d0c74c4094326"
+  },
+  "course_number": "3320",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132aee27d0c74c409434c"
+  },
+  "course_number": "6301",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6241334ae27d0c74c4094363"
+  },
+  "course_number": "3325",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624137f2e27d0c74c40943b5"
+  },
+  "course_number": "1112",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62413809e27d0c74c40943f6"
+  },
+  "course_number": "2323",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241407be27d0c74c40944c4"
+  },
+  "course_number": "3303",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407ce27d0c74c40944ce"
+  },
+  "course_number": "3324",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241407de27d0c74c40944d8"
+  },
+  "course_number": "4322",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414080e27d0c74c40944e3"
+  },
+  "course_number": "6308",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624140abe27d0c74c40944fc"
+  },
+  "course_number": "3351",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62414c33e27d0c74c4094531"
+  },
+  "course_number": "1136",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c4be27d0c74c4094578"
+  },
+  "course_number": "1337",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c4ee27d0c74c4094581"
+  },
+  "course_number": "2305",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414c59e27d0c74c40945a4"
+  },
+  "course_number": "3340",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ea0e27d0c74c40945b8"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eade27d0c74c40945db"
+  },
+  "course_number": "4334",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624132a9e27d0c74c4094338"
+  },
+  "course_number": "4337",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624132b0e27d0c74c4094355"
+  },
+  "course_number": "6308",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6241334ee27d0c74c4094365"
+  },
+  "course_number": "3340",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624133c5e27d0c74c409437a"
+  },
+  "course_number": "4359",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62413809e27d0c74c40943f2"
+  },
+  "course_number": "2127",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241393de27d0c74c4094443"
+  },
+  "course_number": "3339",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "62413966e27d0c74c4094449"
+  },
+  "course_number": "3362",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241397de27d0c74c4094456"
+  },
+  "course_number": "4394",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "62414011e27d0c74c409449f"
+  },
+  "course_number": "3320",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6241407ce27d0c74c40944d1"
+  },
+  "course_number": "3326",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62414c32e27d0c74c409452e"
+  },
+  "course_number": "1134",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414e9ee27d0c74c40945b1"
+  },
+  "course_number": "3345",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ea3e27d0c74c40945c1"
+  },
+  "course_number": "3377",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ea5e27d0c74c40945c7"
+  },
+  "course_number": "4141",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebae27d0c74c409460f"
+  },
+  "course_number": "4397",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb0e27d0c74c40945e6"
+  },
+  "course_number": "4347",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb4e27d0c74c40945f3"
+  },
+  "course_number": "4349",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb6e27d0c74c40945fc"
+  },
+  "course_number": "4365",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed7e27d0c74c4094688"
+  },
+  "course_number": "7301",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f6ee27d0c74c409469b"
+  },
+  "course_number": "3342",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62414f95e27d0c74c409469f"
+  },
+  "course_number": "4317",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624155287a5c14bdce6ae620"
+  },
+  "course_number": "3337",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552e7a5c14bdce6ae645"
+  },
+  "course_number": "6363",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624156017a5c14bdce6ae685"
+  },
+  "course_number": "3390",
+  "subject_prefix": "ECS"
+},{
+  "_id": {
+    "$oid": "6241588c7a5c14bdce6ae6eb"
+  },
+  "course_number": "4358",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624158987a5c14bdce6ae6f0"
+  },
+  "course_number": "4361",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "6241589c7a5c14bdce6ae708"
+  },
+  "course_number": "5318",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b0b7a5c14bdce6ae71b"
+  },
+  "course_number": "3101",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b527a5c14bdce6ae74f"
+  },
+  "course_number": "3320",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b537a5c14bdce6ae755"
+  },
+  "course_number": "4301",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415bd67a5c14bdce6ae775"
+  },
+  "course_number": "6373",
+  "subject_prefix": "EEBM"
+},{
+  "_id": {
+    "$oid": "62414eb9e27d0c74c4094608"
+  },
+  "course_number": "4390",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebfe27d0c74c4094626"
+  },
+  "course_number": "6301",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecae27d0c74c4094652"
+  },
+  "course_number": "6350",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecbe27d0c74c4094657"
+  },
+  "course_number": "6353",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecce27d0c74c409465f"
+  },
+  "course_number": "6360",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f54e27d0c74c409468c"
+  },
+  "course_number": "1310",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624155217a5c14bdce6ae607"
+  },
+  "course_number": "2301",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155257a5c14bdce6ae614"
+  },
+  "course_number": "3310",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155267a5c14bdce6ae617"
+  },
+  "course_number": "3311",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552a7a5c14bdce6ae62c"
+  },
+  "course_number": "4342",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552b7a5c14bdce6ae630"
+  },
+  "course_number": "4355",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552c7a5c14bdce6ae63a"
+  },
+  "course_number": "6302",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552f7a5c14bdce6ae647"
+  },
+  "course_number": "6371",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155307a5c14bdce6ae64e"
+  },
+  "course_number": "7303",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624157df7a5c14bdce6ae6c0"
+  },
+  "course_number": "3315",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624157e07a5c14bdce6ae6c5"
+  },
+  "course_number": "3339",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624158987a5c14bdce6ae6f4"
+  },
+  "course_number": "4363",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624158997a5c14bdce6ae6f8"
+  },
+  "course_number": "4372",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415a057a5c14bdce6ae70a"
+  },
+  "course_number": "1100",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415bd97a5c14bdce6ae777"
+  },
+  "course_number": "6374",
+  "subject_prefix": "EEBM"
+},{
+  "_id": {
+    "$oid": "62415d5c7a5c14bdce6ae784"
+  },
+  "course_number": "5325",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "62414ebae27d0c74c4094611"
+  },
+  "course_number": "4398",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb7e27d0c74c4094601"
+  },
+  "course_number": "4384",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebde27d0c74c409461c"
+  },
+  "course_number": "5303",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebae27d0c74c409460d"
+  },
+  "course_number": "4393",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebde27d0c74c409461e"
+  },
+  "course_number": "5333",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebce27d0c74c4094616"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebee27d0c74c4094621"
+  },
+  "course_number": "5343",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed6e27d0c74c4094682"
+  },
+  "course_number": "6385",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec4e27d0c74c4094635"
+  },
+  "course_number": "6313",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f5de27d0c74c4094691"
+  },
+  "course_number": "2332",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62414ec7e27d0c74c4094646"
+  },
+  "course_number": "6328",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed2e27d0c74c4094675"
+  },
+  "course_number": "6375",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f67e27d0c74c4094697"
+  },
+  "course_number": "3334",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62414ed4e27d0c74c409467b"
+  },
+  "course_number": "6377",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624155267a5c14bdce6ae61a"
+  },
+  "course_number": "3330",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414ed5e27d0c74c409467f"
+  },
+  "course_number": "6382",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed6e27d0c74c4094686"
+  },
+  "course_number": "6396",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624155297a5c14bdce6ae626"
+  },
+  "course_number": "4320",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155287a5c14bdce6ae622"
+  },
+  "course_number": "4302",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552b7a5c14bdce6ae632"
+  },
+  "course_number": "4362",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155297a5c14bdce6ae62a"
+  },
+  "course_number": "4340",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552c7a5c14bdce6ae63c"
+  },
+  "course_number": "6305",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552b7a5c14bdce6ae635"
+  },
+  "course_number": "5321",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552f7a5c14bdce6ae649"
+  },
+  "course_number": "6372",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552c7a5c14bdce6ae638"
+  },
+  "course_number": "6301",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624156bb7a5c14bdce6ae6ab"
+  },
+  "course_number": "3177",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "624155fe7a5c14bdce6ae67b"
+  },
+  "course_number": "3310",
+  "subject_prefix": "ECS"
+},{
+  "_id": {
+    "$oid": "624157e17a5c14bdce6ae6c9"
+  },
+  "course_number": "3342",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624156c97a5c14bdce6ae6b2"
+  },
+  "course_number": "4300",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "6241588b7a5c14bdce6ae6e8"
+  },
+  "course_number": "4357",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624157de7a5c14bdce6ae6bd"
+  },
+  "course_number": "3314",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "6241589b7a5c14bdce6ae700"
+  },
+  "course_number": "4694",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624157e17a5c14bdce6ae6c7"
+  },
+  "course_number": "3340",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b3d7a5c14bdce6ae72b"
+  },
+  "course_number": "3110",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "624157e17a5c14bdce6ae6cb"
+  },
+  "course_number": "3345",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b487a5c14bdce6ae731"
+  },
+  "course_number": "3111",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "624158217a5c14bdce6ae6d5"
+  },
+  "course_number": "4343",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b517a5c14bdce6ae74c"
+  },
+  "course_number": "3311",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "624158897a5c14bdce6ae6e2"
+  },
+  "course_number": "4352",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b527a5c14bdce6ae752"
+  },
+  "course_number": "3350",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "6241588a7a5c14bdce6ae6e5"
+  },
+  "course_number": "4353",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b547a5c14bdce6ae75b"
+  },
+  "course_number": "4310",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b507a5c14bdce6ae749"
+  },
+  "course_number": "3310",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415cd67a5c14bdce6ae77d"
+  },
+  "course_number": "6325",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "62415b577a5c14bdce6ae766"
+  },
+  "course_number": "4363",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b587a5c14bdce6ae76a"
+  },
+  "course_number": "4368",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415c567a5c14bdce6ae779"
+  },
+  "course_number": "6323",
+  "subject_prefix": "EECS"
+},{
+  "_id": {
+    "$oid": "62415c5a7a5c14bdce6ae77b"
+  },
+  "course_number": "6331",
+  "subject_prefix": "EECS"
+},{
+  "_id": {
+    "$oid": "62415d5f7a5c14bdce6ae786"
+  },
+  "course_number": "6301",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "62415d627a5c14bdce6ae788"
+  },
+  "course_number": "6302",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "62414ebfe27d0c74c4094624"
+  },
+  "course_number": "5V81",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec7e27d0c74c4094642"
+  },
+  "course_number": "6323",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec8e27d0c74c4094648"
+  },
+  "course_number": "6331",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecce27d0c74c409465c"
+  },
+  "course_number": "6359",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed2e27d0c74c4094671"
+  },
+  "course_number": "6366",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624155297a5c14bdce6ae628"
+  },
+  "course_number": "4333",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552a7a5c14bdce6ae62e"
+  },
+  "course_number": "4351",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552e7a5c14bdce6ae643"
+  },
+  "course_number": "6352",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155fe7a5c14bdce6ae678"
+  },
+  "course_number": "3301",
+  "subject_prefix": "ECS"
+},{
+  "_id": {
+    "$oid": "624155ff7a5c14bdce6ae67d"
+  },
+  "course_number": "3361",
+  "subject_prefix": "ECS"
+},{
+  "_id": {
+    "$oid": "624156b47a5c14bdce6ae6a6"
+  },
+  "course_number": "2100",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "624156b77a5c14bdce6ae6a9"
+  },
+  "course_number": "3100",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "624156cb7a5c14bdce6ae6b4"
+  },
+  "course_number": "4378",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "624156f17a5c14bdce6ae6b7"
+  },
+  "course_number": "5177",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "624158137a5c14bdce6ae6d2"
+  },
+  "course_number": "3380",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624158637a5c14bdce6ae6db"
+  },
+  "course_number": "4345",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b4f7a5c14bdce6ae745"
+  },
+  "course_number": "3302",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b577a5c14bdce6ae764"
+  },
+  "course_number": "4361",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b577a5c14bdce6ae768"
+  },
+  "course_number": "4365",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b587a5c14bdce6ae76c"
+  },
+  "course_number": "4388",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415d6f7a5c14bdce6ae78d"
+  },
+  "course_number": "6304",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "62414eb9e27d0c74c409460b"
+  },
+  "course_number": "4392",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebbe27d0c74c4094613"
+  },
+  "course_number": "4485",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec6e27d0c74c409463d"
+  },
+  "course_number": "6315",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec7e27d0c74c4094644"
+  },
+  "course_number": "6326",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec9e27d0c74c4094650"
+  },
+  "course_number": "6349",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecae27d0c74c4094655"
+  },
+  "course_number": "6352",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecbe27d0c74c4094659"
+  },
+  "course_number": "6356",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed1e27d0c74c409466e"
+  },
+  "course_number": "6364",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f5ae27d0c74c409468f"
+  },
+  "course_number": "2321",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624155f57a5c14bdce6ae654"
+  },
+  "course_number": "1100",
+  "subject_prefix": "ECS"
+},{
+  "_id": {
+    "$oid": "624156c17a5c14bdce6ae6af"
+  },
+  "course_number": "3179",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "624158897a5c14bdce6ae6de"
+  },
+  "course_number": "4351",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624158977a5c14bdce6ae6ee"
+  },
+  "course_number": "4359",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b4c7a5c14bdce6ae73d"
+  },
+  "course_number": "3150",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b4e7a5c14bdce6ae742"
+  },
+  "course_number": "3301",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b547a5c14bdce6ae759"
+  },
+  "course_number": "4304",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b557a5c14bdce6ae75d"
+  },
+  "course_number": "4330",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62414eb2e27d0c74c40945ed"
+  },
+  "course_number": "4348",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb6e27d0c74c40945fa"
+  },
+  "course_number": "4361",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb7e27d0c74c40945fe"
+  },
+  "course_number": "4375",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414eb8e27d0c74c4094606"
+  },
+  "course_number": "4389",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec5e27d0c74c4094638"
+  },
+  "course_number": "6314",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec6e27d0c74c4094640"
+  },
+  "course_number": "6320",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec8e27d0c74c409464c"
+  },
+  "course_number": "6334",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed5e27d0c74c409467d"
+  },
+  "course_number": "6378",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed6e27d0c74c4094684"
+  },
+  "course_number": "6390",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f6be27d0c74c4094699"
+  },
+  "course_number": "3340",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624155237a5c14bdce6ae60d"
+  },
+  "course_number": "2302",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155277a5c14bdce6ae61e"
+  },
+  "course_number": "3332",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241552d7a5c14bdce6ae63e"
+  },
+  "course_number": "6306",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155307a5c14bdce6ae64c"
+  },
+  "course_number": "6380",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155307a5c14bdce6ae650"
+  },
+  "course_number": "7309",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624155317a5c14bdce6ae652"
+  },
+  "course_number": "7315",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624156fa7a5c14bdce6ae6ba"
+  },
+  "course_number": "5179",
+  "subject_prefix": "ECSC"
+},{
+  "_id": {
+    "$oid": "62415a097a5c14bdce6ae716"
+  },
+  "course_number": "1202",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b557a5c14bdce6ae75f"
+  },
+  "course_number": "4340",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b567a5c14bdce6ae761"
+  },
+  "course_number": "4342",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b597a5c14bdce6ae770"
+  },
+  "course_number": "4389",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b5a7a5c14bdce6ae773"
+  },
+  "course_number": "4391",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62414eb5e27d0c74c40945f8"
+  },
+  "course_number": "4352",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ebce27d0c74c4094618"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec3e27d0c74c4094632"
+  },
+  "course_number": "6304",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec8e27d0c74c409464a"
+  },
+  "course_number": "6332",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ec9e27d0c74c409464e"
+  },
+  "course_number": "6343",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ecfe27d0c74c4094667"
+  },
+  "course_number": "6363",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414ed2e27d0c74c4094673"
+  },
+  "course_number": "6367",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62414f60e27d0c74c4094693"
+  },
+  "course_number": "2334",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62414f64e27d0c74c4094695"
+  },
+  "course_number": "2V71",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62414f92e27d0c74c409469d"
+  },
+  "course_number": "4314",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624155287a5c14bdce6ae624"
+  },
+  "course_number": "4310",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624158107a5c14bdce6ae6cf"
+  },
+  "course_number": "3371",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624158607a5c14bdce6ae6d9"
+  },
+  "course_number": "4344",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "6241589a7a5c14bdce6ae6fd"
+  },
+  "course_number": "4693",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62415b0a7a5c14bdce6ae718"
+  },
+  "course_number": "2310",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b0d7a5c14bdce6ae721"
+  },
+  "course_number": "3102",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415b4a7a5c14bdce6ae736"
+  },
+  "course_number": "3120",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62415cdc7a5c14bdce6ae780"
+  },
+  "course_number": "6326",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "62415cdf7a5c14bdce6ae782"
+  },
+  "course_number": "6378",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "62415d9a7a5c14bdce6ae792"
+  },
+  "course_number": "6308",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "6241601b7a5c14bdce6ae7a7"
+  },
+  "course_number": "6355",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "62415d9d7a5c14bdce6ae794"
+  },
+  "course_number": "6370",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "624160227a5c14bdce6ae7ab"
+  },
+  "course_number": "6396",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "62415e1c7a5c14bdce6ae798"
+  },
+  "course_number": "8V40",
+  "subject_prefix": "EEGR"
+},{
+  "_id": {
+    "$oid": "624163f47a5c14bdce6ae810"
+  },
+  "course_number": "6370",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f57a5c14bdce6ae813"
+  },
+  "course_number": "6375",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624164387a5c14bdce6ae821"
+  },
+  "course_number": "1110",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643a7a5c14bdce6ae829"
+  },
+  "course_number": "2302",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643b7a5c14bdce6ae833"
+  },
+  "course_number": "6302",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643c7a5c14bdce6ae837"
+  },
+  "course_number": "6313",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241659f7a5c14bdce6ae84d"
+  },
+  "course_number": "3200",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624166b07a5c14bdce6ae876"
+  },
+  "course_number": "3350",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624166c47a5c14bdce6ae883"
+  },
+  "course_number": "3380",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670e7a5c14bdce6ae8cb"
+  },
+  "course_number": "6315",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624169bc7a5c14bdce6ae926"
+  },
+  "course_number": "5319",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e27a5c14bdce6ae932"
+  },
+  "course_number": "5398",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624163207a5c14bdce6ae7b4"
+  },
+  "course_number": "6344",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624169e57a5c14bdce6ae942"
+  },
+  "course_number": "7V00",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416aeb7a5c14bdce6ae949"
+  },
+  "course_number": "2305",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624163227a5c14bdce6ae7be"
+  },
+  "course_number": "6363",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62416aee7a5c14bdce6ae94b"
+  },
+  "course_number": "3304",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6241638a7a5c14bdce6ae7e4"
+  },
+  "course_number": "6330",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "624163ee7a5c14bdce6ae7f0"
+  },
+  "course_number": "3320",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f67a5c14bdce6ae81a"
+  },
+  "course_number": "6392",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624167047a5c14bdce6ae8a4"
+  },
+  "course_number": "4380",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670c7a5c14bdce6ae8c5"
+  },
+  "course_number": "6311",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670e7a5c14bdce6ae8cd"
+  },
+  "course_number": "6321",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167107a5c14bdce6ae8da"
+  },
+  "course_number": "6355",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167117a5c14bdce6ae8dc"
+  },
+  "course_number": "6360",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167127a5c14bdce6ae8e2"
+  },
+  "course_number": "6368",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624169267a5c14bdce6ae903"
+  },
+  "course_number": "1104",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241697f7a5c14bdce6ae918"
+  },
+  "course_number": "3421",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e37a5c14bdce6ae939"
+  },
+  "course_number": "6381",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416b387a5c14bdce6ae962"
+  },
+  "course_number": "6325",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624163217a5c14bdce6ae7bc"
+  },
+  "course_number": "6362",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624163787a5c14bdce6ae7cd"
+  },
+  "course_number": "3300",
+  "subject_prefix": "ENGR"
+},{
+  "_id": {
+    "$oid": "624163ee7a5c14bdce6ae7f2"
+  },
+  "course_number": "3360",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f37a5c14bdce6ae80a"
+  },
+  "course_number": "6360",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f57a5c14bdce6ae818"
+  },
+  "course_number": "6388",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163fb7a5c14bdce6ae81f"
+  },
+  "course_number": "2302",
+  "subject_prefix": "ENVR"
+},{
+  "_id": {
+    "$oid": "6241643b7a5c14bdce6ae830"
+  },
+  "course_number": "2305",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643c7a5c14bdce6ae835"
+  },
+  "course_number": "6311",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624164507a5c14bdce6ae845"
+  },
+  "course_number": "2332",
+  "subject_prefix": "FILM"
+},{
+  "_id": {
+    "$oid": "624166b07a5c14bdce6ae87a"
+  },
+  "course_number": "3360",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167017a5c14bdce6ae894"
+  },
+  "course_number": "4310",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167027a5c14bdce6ae899"
+  },
+  "course_number": "4331",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167047a5c14bdce6ae8a2"
+  },
+  "course_number": "4345",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670f7a5c14bdce6ae8d6"
+  },
+  "course_number": "6350",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624169277a5c14bdce6ae909"
+  },
+  "course_number": "1304",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241693f7a5c14bdce6ae911"
+  },
+  "course_number": "2310",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169bc7a5c14bdce6ae922"
+  },
+  "course_number": "5310",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169bc7a5c14bdce6ae924"
+  },
+  "course_number": "5315",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416a667a5c14bdce6ae947"
+  },
+  "course_number": "2311",
+  "subject_prefix": "GERM"
+},{
+  "_id": {
+    "$oid": "62415e1b7a5c14bdce6ae796"
+  },
+  "course_number": "6316",
+  "subject_prefix": "EEGR"
+},{
+  "_id": {
+    "$oid": "62416af87a5c14bdce6ae952"
+  },
+  "course_number": "4380",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b317a5c14bdce6ae960"
+  },
+  "course_number": "6317",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624163217a5c14bdce6ae7ba"
+  },
+  "course_number": "6360",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62416b677a5c14bdce6ae96b"
+  },
+  "course_number": "6389",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624163757a5c14bdce6ae7c2"
+  },
+  "course_number": "2300",
+  "subject_prefix": "ENGR"
+},{
+  "_id": {
+    "$oid": "62416be37a5c14bdce6ae96f"
+  },
+  "course_number": "2107",
+  "subject_prefix": "GOVT"
+},{
+  "_id": {
+    "$oid": "624163ef7a5c14bdce6ae7f9"
+  },
+  "course_number": "4335",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624170417a5c14bdce6ae9a6"
+  },
+  "course_number": "6312",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624163f37a5c14bdce6ae80e"
+  },
+  "course_number": "6362",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624170437a5c14bdce6ae9ac"
+  },
+  "course_number": "6338",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241643e7a5c14bdce6ae840"
+  },
+  "course_number": "7313",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624166b57a5c14bdce6ae87e"
+  },
+  "course_number": "3370",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624170437a5c14bdce6ae9ae"
+  },
+  "course_number": "6340",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624167007a5c14bdce6ae88f"
+  },
+  "course_number": "4300",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624170447a5c14bdce6ae9b2"
+  },
+  "course_number": "6349",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624167067a5c14bdce6ae8aa"
+  },
+  "course_number": "4V80",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624170447a5c14bdce6ae9b4"
+  },
+  "course_number": "6350",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241670d7a5c14bdce6ae8c8"
+  },
+  "course_number": "6314",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670f7a5c14bdce6ae8d1"
+  },
+  "course_number": "6325",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167137a5c14bdce6ae8e6"
+  },
+  "course_number": "6382",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241685a7a5c14bdce6ae8f9"
+  },
+  "course_number": "3370",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624169257a5c14bdce6ae8ff"
+  },
+  "course_number": "1103",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e27a5c14bdce6ae934"
+  },
+  "course_number": "5V08",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416b007a5c14bdce6ae958"
+  },
+  "course_number": "5310",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b677a5c14bdce6ae969"
+  },
+  "course_number": "6382",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416cb07a5c14bdce6ae984"
+  },
+  "course_number": "2300",
+  "subject_prefix": "GST"
+},{
+  "_id": {
+    "$oid": "624170437a5c14bdce6ae9b0"
+  },
+  "course_number": "6346",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170447a5c14bdce6ae9b6"
+  },
+  "course_number": "6357",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62415e207a5c14bdce6ae79a"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "EEGR"
+},{
+  "_id": {
+    "$oid": "62415f967a5c14bdce6ae7a3"
+  },
+  "course_number": "6354",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "62415e9d7a5c14bdce6ae79c"
+  },
+  "course_number": "6319",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624160337a5c14bdce6ae7b1"
+  },
+  "course_number": "7V89",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "6241638a7a5c14bdce6ae7e1"
+  },
+  "course_number": "3300",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "624163f17a5c14bdce6ae802"
+  },
+  "course_number": "4V00",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624164397a5c14bdce6ae824"
+  },
+  "course_number": "2301",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643d7a5c14bdce6ae83c"
+  },
+  "course_number": "6316",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643d7a5c14bdce6ae83e"
+  },
+  "course_number": "6346",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241643e7a5c14bdce6ae843"
+  },
+  "course_number": "7390",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624164517a5c14bdce6ae84b"
+  },
+  "course_number": "3325",
+  "subject_prefix": "FILM"
+},{
+  "_id": {
+    "$oid": "624165a07a5c14bdce6ae852"
+  },
+  "course_number": "3305",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167047a5c14bdce6ae8a0"
+  },
+  "course_number": "4340",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167097a5c14bdce6ae8b9"
+  },
+  "course_number": "6306",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670b7a5c14bdce6ae8c0"
+  },
+  "course_number": "6310",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670f7a5c14bdce6ae8d3"
+  },
+  "course_number": "6326",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167947a5c14bdce6ae8ee"
+  },
+  "course_number": "2311",
+  "subject_prefix": "FREN"
+},{
+  "_id": {
+    "$oid": "624168537a5c14bdce6ae8f4"
+  },
+  "course_number": "3304",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624168567a5c14bdce6ae8f7"
+  },
+  "course_number": "3357",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624169267a5c14bdce6ae905"
+  },
+  "course_number": "1303",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241692a7a5c14bdce6ae90d"
+  },
+  "course_number": "2305",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169767a5c14bdce6ae914"
+  },
+  "course_number": "2409",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169bb7a5c14bdce6ae91e"
+  },
+  "course_number": "4320",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169bd7a5c14bdce6ae928"
+  },
+  "course_number": "5324",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416cb37a5c14bdce6ae986"
+  },
+  "course_number": "3301",
+  "subject_prefix": "GST"
+},{
+  "_id": {
+    "$oid": "62416cb77a5c14bdce6ae988"
+  },
+  "course_number": "3302",
+  "subject_prefix": "GST"
+},{
+  "_id": {
+    "$oid": "624170427a5c14bdce6ae9aa"
+  },
+  "course_number": "6330",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624163207a5c14bdce6ae7b6"
+  },
+  "course_number": "6349",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "6241637c7a5c14bdce6ae7d7"
+  },
+  "course_number": "3341",
+  "subject_prefix": "ENGR"
+},{
+  "_id": {
+    "$oid": "6241638b7a5c14bdce6ae7e6"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "624163ef7a5c14bdce6ae7f4"
+  },
+  "course_number": "4330",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163ef7a5c14bdce6ae7f6"
+  },
+  "course_number": "4331",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624165a07a5c14bdce6ae850"
+  },
+  "course_number": "3300",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624166af7a5c14bdce6ae874"
+  },
+  "course_number": "3340",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167007a5c14bdce6ae88c"
+  },
+  "course_number": "3395",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167037a5c14bdce6ae89b"
+  },
+  "course_number": "4334",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167037a5c14bdce6ae89d"
+  },
+  "course_number": "4337",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167077a5c14bdce6ae8af"
+  },
+  "course_number": "6301",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670b7a5c14bdce6ae8be"
+  },
+  "course_number": "6308",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167907a5c14bdce6ae8ec"
+  },
+  "course_number": "1311",
+  "subject_prefix": "FREN"
+},{
+  "_id": {
+    "$oid": "6241684d7a5c14bdce6ae8f0"
+  },
+  "course_number": "2302",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624169bb7a5c14bdce6ae920"
+  },
+  "course_number": "4430",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416a617a5c14bdce6ae944"
+  },
+  "course_number": "1311",
+  "subject_prefix": "GERM"
+},{
+  "_id": {
+    "$oid": "62416b2a7a5c14bdce6ae95c"
+  },
+  "course_number": "5324",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b3d7a5c14bdce6ae964"
+  },
+  "course_number": "6379",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b667a5c14bdce6ae967"
+  },
+  "course_number": "6381",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b677a5c14bdce6ae96d"
+  },
+  "course_number": "7387",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62415e9f7a5c14bdce6ae79e"
+  },
+  "course_number": "6320",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624160197a5c14bdce6ae7a5"
+  },
+  "course_number": "6311",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "624163227a5c14bdce6ae7c0"
+  },
+  "course_number": "6390",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624163ec7a5c14bdce6ae7e8"
+  },
+  "course_number": "3301",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f17a5c14bdce6ae7fe"
+  },
+  "course_number": "4340",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f17a5c14bdce6ae800"
+  },
+  "course_number": "4350",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f37a5c14bdce6ae80c"
+  },
+  "course_number": "6361",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f57a5c14bdce6ae815"
+  },
+  "course_number": "6380",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624165a17a5c14bdce6ae856"
+  },
+  "course_number": "3320",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624166797a5c14bdce6ae86d"
+  },
+  "course_number": "3330",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624166b17a5c14bdce6ae87c"
+  },
+  "course_number": "3365",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624166c87a5c14bdce6ae886"
+  },
+  "course_number": "3390",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167057a5c14bdce6ae8a6"
+  },
+  "course_number": "4390",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241670e7a5c14bdce6ae8cf"
+  },
+  "course_number": "6322",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6241685d7a5c14bdce6ae8fb"
+  },
+  "course_number": "3377",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624169b47a5c14bdce6ae91c"
+  },
+  "course_number": "3464",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e07a5c14bdce6ae92b"
+  },
+  "course_number": "5325",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e17a5c14bdce6ae92f"
+  },
+  "course_number": "5384",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e47a5c14bdce6ae93b"
+  },
+  "course_number": "6383",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e47a5c14bdce6ae93e"
+  },
+  "course_number": "7110",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e57a5c14bdce6ae940"
+  },
+  "course_number": "7190",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416af27a5c14bdce6ae94d"
+  },
+  "course_number": "4317",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b037a5c14bdce6ae95a"
+  },
+  "course_number": "5319",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416b2b7a5c14bdce6ae95e"
+  },
+  "course_number": "6301",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416be87a5c14bdce6ae972"
+  },
+  "course_number": "2305",
+  "subject_prefix": "GOVT"
+},{
+  "_id": {
+    "$oid": "624170417a5c14bdce6ae9a4"
+  },
+  "course_number": "6302",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170457a5c14bdce6ae9ba"
+  },
+  "course_number": "6376",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62415d757a5c14bdce6ae790"
+  },
+  "course_number": "6306",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "62415f1b7a5c14bdce6ae7a1"
+  },
+  "course_number": "6310",
+  "subject_prefix": "EEOP"
+},{
+  "_id": {
+    "$oid": "6241601e7a5c14bdce6ae7a9"
+  },
+  "course_number": "6395",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "624163f27a5c14bdce6ae805"
+  },
+  "course_number": "6311",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f27a5c14bdce6ae808"
+  },
+  "course_number": "6315",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624163f67a5c14bdce6ae81c"
+  },
+  "course_number": "6V97",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624167067a5c14bdce6ae8ad"
+  },
+  "course_number": "6300",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167117a5c14bdce6ae8df"
+  },
+  "course_number": "6364",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167127a5c14bdce6ae8e4"
+  },
+  "course_number": "6370",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624167137a5c14bdce6ae8e8"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624168507a5c14bdce6ae8f2"
+  },
+  "course_number": "2303",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624168607a5c14bdce6ae8fd"
+  },
+  "course_number": "4380",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624169287a5c14bdce6ae90b"
+  },
+  "course_number": "2302",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241692d7a5c14bdce6ae90f"
+  },
+  "course_number": "2306",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241697d7a5c14bdce6ae916"
+  },
+  "course_number": "3304",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624169e17a5c14bdce6ae92d"
+  },
+  "course_number": "5381",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62416af37a5c14bdce6ae94f"
+  },
+  "course_number": "4326",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416afa7a5c14bdce6ae954"
+  },
+  "course_number": "4384",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416afe7a5c14bdce6ae956"
+  },
+  "course_number": "4385",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62416bf97a5c14bdce6ae97a"
+  },
+  "course_number": "2306",
+  "subject_prefix": "GOVT"
+},{
+  "_id": {
+    "$oid": "624170457a5c14bdce6ae9b8"
+  },
+  "course_number": "6374",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170497a5c14bdce6ae9cd"
+  },
+  "course_number": "7364",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170487a5c14bdce6ae9cb"
+  },
+  "course_number": "7351",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170477a5c14bdce6ae9c3"
+  },
+  "course_number": "7309",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241706e7a5c14bdce6ae9d9"
+  },
+  "course_number": "6315",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6241706e7a5c14bdce6ae9dc"
+  },
+  "course_number": "6319",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624170f27a5c14bdce6aea09"
+  },
+  "course_number": "3327",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f67a5c14bdce6aea1d"
+  },
+  "course_number": "4V99",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f77a5c14bdce6aea23"
+  },
+  "course_number": "6360",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624171457a5c14bdce6aea2d"
+  },
+  "course_number": "3101",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624170f37a5c14bdce6aea0d"
+  },
+  "course_number": "3387",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624171a57a5c14bdce6aea57"
+  },
+  "course_number": "4321",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624171ef7a5c14bdce6aea6f"
+  },
+  "course_number": "6382",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624170f57a5c14bdce6aea1a"
+  },
+  "course_number": "4378",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624171447a5c14bdce6aea25"
+  },
+  "course_number": "1301",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624171f07a5c14bdce6aea71"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624171477a5c14bdce6aea35"
+  },
+  "course_number": "3305",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624173577a5c14bdce6aea93"
+  },
+  "course_number": "6355",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624171487a5c14bdce6aea3a"
+  },
+  "course_number": "4108",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624173697a5c14bdce6aea9d"
+  },
+  "course_number": "7360",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6241714a7a5c14bdce6aea46"
+  },
+  "course_number": "4V01",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "6241738a7a5c14bdce6aea9f"
+  },
+  "course_number": "7380",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624171ef7a5c14bdce6aea6d"
+  },
+  "course_number": "6380",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624174c97a5c14bdce6aeab4"
+  },
+  "course_number": "1301",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "624173617a5c14bdce6aea99"
+  },
+  "course_number": "6392",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6241769b7a5c14bdce6aeae9"
+  },
+  "course_number": "4320",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624174127a5c14bdce6aeaa6"
+  },
+  "course_number": "6320",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624174227a5c14bdce6aeab0"
+  },
+  "course_number": "7314",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624177217a5c14bdce6aeb01"
+  },
+  "course_number": "4302",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "624179007a5c14bdce6aeb1e"
+  },
+  "course_number": "2368",
+  "subject_prefix": "ISNS"
+},{
+  "_id": {
+    "$oid": "624177277a5c14bdce6aeb05"
+  },
+  "course_number": "4376",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "624179d57a5c14bdce6aeb24"
+  },
+  "course_number": "3300",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "6241772e7a5c14bdce6aeb09"
+  },
+  "course_number": "4396",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62417abb7a5c14bdce6aeb72"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624178ed7a5c14bdce6aeb16"
+  },
+  "course_number": "2359",
+  "subject_prefix": "ISNS"
+},{
+  "_id": {
+    "$oid": "62417f857a5c14bdce6aeb9b"
+  },
+  "course_number": "3300",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417ab87a5c14bdce6aeb62"
+  },
+  "course_number": "4353",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417f897a5c14bdce6aebab"
+  },
+  "course_number": "3321",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f837a5c14bdce6aeb91"
+  },
+  "course_number": "2331",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f8a7a5c14bdce6aebb1"
+  },
+  "course_number": "3329",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f8a7a5c14bdce6aebb5"
+  },
+  "course_number": "3335",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f847a5c14bdce6aeb97"
+  },
+  "course_number": "2341",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f9e7a5c14bdce6aebc5"
+  },
+  "course_number": "5V38",
+  "subject_prefix": "MAIS"
+},{
+  "_id": {
+    "$oid": "62417f897a5c14bdce6aebad"
+  },
+  "course_number": "3322",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417fcb7a5c14bdce6aebc7"
+  },
+  "course_number": "6102",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "62417f8b7a5c14bdce6aebb9"
+  },
+  "course_number": "3343",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6241a538e0a87a87f38b1a88"
+  },
+  "course_number": "1326",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a52ee0a87a87f38b1a6a"
+  },
+  "course_number": "1306",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a53ee0a87a87f38b1a95"
+  },
+  "course_number": "2312",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a532e0a87a87f38b1a78"
+  },
+  "course_number": "1325",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a541e0a87a87f38b1a9d"
+  },
+  "course_number": "2333",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a542e0a87a87f38b1aa1"
+  },
+  "course_number": "2370",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a81ee0a87a87f38b1b0c"
+  },
+  "course_number": "2415",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "624170ea7a5c14bdce6ae9e7"
+  },
+  "course_number": "1301",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6241706f7a5c14bdce6ae9e1"
+  },
+  "course_number": "6365",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624170f17a5c14bdce6aea02"
+  },
+  "course_number": "3301",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f17a5c14bdce6aea05"
+  },
+  "course_number": "3302",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f27a5c14bdce6aea07"
+  },
+  "course_number": "3320",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f47a5c14bdce6aea14"
+  },
+  "course_number": "4344",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f37a5c14bdce6aea10"
+  },
+  "course_number": "3398",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f57a5c14bdce6aea16"
+  },
+  "course_number": "4357",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f67a5c14bdce6aea1f"
+  },
+  "course_number": "6301",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624171487a5c14bdce6aea38"
+  },
+  "course_number": "3310",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624171ec7a5c14bdce6aea6b"
+  },
+  "course_number": "6336",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624171497a5c14bdce6aea3f"
+  },
+  "course_number": "4305",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "6241735a7a5c14bdce6aea95"
+  },
+  "course_number": "6381",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6241740e7a5c14bdce6aeaa4"
+  },
+  "course_number": "6314",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624171937a5c14bdce6aea48"
+  },
+  "course_number": "3301",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624174187a5c14bdce6aeaaa"
+  },
+  "course_number": "6351",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6241719b7a5c14bdce6aea51"
+  },
+  "course_number": "3310",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624175457a5c14bdce6aeac6"
+  },
+  "course_number": "6300",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "624171d57a5c14bdce6aea62"
+  },
+  "course_number": "6324",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6241769c7a5c14bdce6aeaf1"
+  },
+  "course_number": "6304",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241735e7a5c14bdce6aea97"
+  },
+  "course_number": "6391",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6241769c7a5c14bdce6aeaf3"
+  },
+  "course_number": "6310",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241769d7a5c14bdce6aeaf5"
+  },
+  "course_number": "6365",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241741f7a5c14bdce6aeaae"
+  },
+  "course_number": "7305",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62417a837a5c14bdce6aeb49"
+  },
+  "course_number": "3390",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624175477a5c14bdce6aeacc"
+  },
+  "course_number": "6321",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "62417ab77a5c14bdce6aeb5f"
+  },
+  "course_number": "4351",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624179d47a5c14bdce6aeb21"
+  },
+  "course_number": "3200",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417aba7a5c14bdce6aeb6c"
+  },
+  "course_number": "4370",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417a837a5c14bdce6aeb44"
+  },
+  "course_number": "3312",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417b377a5c14bdce6aeb75"
+  },
+  "course_number": "1311",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "62417ab57a5c14bdce6aeb52"
+  },
+  "course_number": "4312",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417f887a5c14bdce6aeba9"
+  },
+  "course_number": "3318",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f8a7a5c14bdce6aebb3"
+  },
+  "course_number": "3330",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417ab57a5c14bdce6aeb54"
+  },
+  "course_number": "4320",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417ab77a5c14bdce6aeb5c"
+  },
+  "course_number": "4342",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417f857a5c14bdce6aeb9d"
+  },
+  "course_number": "3312",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6241a52fe0a87a87f38b1a6d"
+  },
+  "course_number": "1314",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a823e0a87a87f38b1b1b"
+  },
+  "course_number": "2417",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a843e0a87a87f38b1b70"
+  },
+  "course_number": "2419",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "624170467a5c14bdce6ae9be"
+  },
+  "course_number": "6395",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170457a5c14bdce6ae9bc"
+  },
+  "course_number": "6389",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170477a5c14bdce6ae9c1"
+  },
+  "course_number": "7121",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170477a5c14bdce6ae9c5"
+  },
+  "course_number": "7310",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170497a5c14bdce6ae9cf"
+  },
+  "course_number": "7372",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624170f57a5c14bdce6aea18"
+  },
+  "course_number": "4358",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f67a5c14bdce6aea21"
+  },
+  "course_number": "6325",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624171447a5c14bdce6aea29"
+  },
+  "course_number": "1322",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624171df7a5c14bdce6aea65"
+  },
+  "course_number": "6330",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624171e37a5c14bdce6aea68"
+  },
+  "course_number": "6334",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6241761f7a5c14bdce6aead1"
+  },
+  "course_number": "3310",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624176977a5c14bdce6aeae7"
+  },
+  "course_number": "3V92",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241769e7a5c14bdce6aeafc"
+  },
+  "course_number": "7301",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624177e97a5c14bdce6aeb0c"
+  },
+  "course_number": "4V50",
+  "subject_prefix": "ISAH"
+},{
+  "_id": {
+    "$oid": "62417ab57a5c14bdce6aeb56"
+  },
+  "course_number": "4330",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "6241706d7a5c14bdce6ae9d4"
+  },
+  "course_number": "5350",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "62417aba7a5c14bdce6aeb70"
+  },
+  "course_number": "4390",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624170f07a5c14bdce6ae9fe"
+  },
+  "course_number": "2301",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f17a5c14bdce6aea00"
+  },
+  "course_number": "2330",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62417b3d7a5c14bdce6aeb79"
+  },
+  "course_number": "2311",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "62417f877a5c14bdce6aeba4"
+  },
+  "course_number": "3316",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f8b7a5c14bdce6aebb7"
+  },
+  "course_number": "3339",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417fce7a5c14bdce6aebd5"
+  },
+  "course_number": "6V05",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "6241719e7a5c14bdce6aea54"
+  },
+  "course_number": "3311",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624171ae7a5c14bdce6aea5d"
+  },
+  "course_number": "6321",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6241771a7a5c14bdce6aeafe"
+  },
+  "course_number": "3349",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62417a827a5c14bdce6aeb3e"
+  },
+  "course_number": "3311",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417a8a7a5c14bdce6aeb4c"
+  },
+  "course_number": "4300",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417c377a5c14bdce6aeb7d"
+  },
+  "course_number": "6300",
+  "subject_prefix": "LATS"
+},{
+  "_id": {
+    "$oid": "6241a7c7e0a87a87f38b1aea"
+  },
+  "course_number": "2414",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "624170487a5c14bdce6ae9c9"
+  },
+  "course_number": "7320",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241706d7a5c14bdce6ae9d7"
+  },
+  "course_number": "6312",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6241706f7a5c14bdce6ae9de"
+  },
+  "course_number": "6360",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6241706f7a5c14bdce6ae9e3"
+  },
+  "course_number": "6395",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624171477a5c14bdce6aea33"
+  },
+  "course_number": "3300",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624171497a5c14bdce6aea41"
+  },
+  "course_number": "4380",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624172727a5c14bdce6aea74"
+  },
+  "course_number": "3199",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "6241734d7a5c14bdce6aea8c"
+  },
+  "course_number": "6315",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624173507a5c14bdce6aea8e"
+  },
+  "course_number": "6339",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624173547a5c14bdce6aea90"
+  },
+  "course_number": "6354",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624174087a5c14bdce6aeaa1"
+  },
+  "course_number": "6313",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6241741a7a5c14bdce6aeaac"
+  },
+  "course_number": "6395",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624174467a5c14bdce6aeab2"
+  },
+  "course_number": "7387",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624175457a5c14bdce6aeac4"
+  },
+  "course_number": "3351",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "624175467a5c14bdce6aeac9"
+  },
+  "course_number": "6320",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "624175477a5c14bdce6aeacf"
+  },
+  "course_number": "6323",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "6241769b7a5c14bdce6aeaeb"
+  },
+  "course_number": "4373",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241769d7a5c14bdce6aeaf9"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624177247a5c14bdce6aeb03"
+  },
+  "course_number": "4308",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "6241772a7a5c14bdce6aeb07"
+  },
+  "course_number": "4384",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "624178667a5c14bdce6aeb0e"
+  },
+  "course_number": "3310",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "6241786c7a5c14bdce6aeb13"
+  },
+  "course_number": "4V89",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "62417ab87a5c14bdce6aeb64"
+  },
+  "course_number": "4355",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417b417a5c14bdce6aeb7b"
+  },
+  "course_number": "3311",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "62417f897a5c14bdce6aebaf"
+  },
+  "course_number": "3323",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f9d7a5c14bdce6aebbf"
+  },
+  "course_number": "5300",
+  "subject_prefix": "MAIS"
+},{
+  "_id": {
+    "$oid": "6241a839e0a87a87f38b1b53"
+  },
+  "course_number": "2418",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a846e0a87a87f38b1b7a"
+  },
+  "course_number": "2420",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "624170707a5c14bdce6ae9e5"
+  },
+  "course_number": "6V20",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624170f07a5c14bdce6ae9fb"
+  },
+  "course_number": "1302",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f37a5c14bdce6aea0b"
+  },
+  "course_number": "3337",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624170f47a5c14bdce6aea12"
+  },
+  "course_number": "4330",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624171487a5c14bdce6aea3d"
+  },
+  "course_number": "4304",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624171a87a5c14bdce6aea5a"
+  },
+  "course_number": "6320",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624171b17a5c14bdce6aea5f"
+  },
+  "course_number": "6323",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624173647a5c14bdce6aea9b"
+  },
+  "course_number": "6399",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624174157a5c14bdce6aeaa8"
+  },
+  "course_number": "6338",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6241769b7a5c14bdce6aeaee"
+  },
+  "course_number": "6204",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241769d7a5c14bdce6aeaf7"
+  },
+  "course_number": "6V92",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624178687a5c14bdce6aeb10"
+  },
+  "course_number": "4303",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "624178f57a5c14bdce6aeb1a"
+  },
+  "course_number": "2367",
+  "subject_prefix": "ISNS"
+},{
+  "_id": {
+    "$oid": "62417ab47a5c14bdce6aeb50"
+  },
+  "course_number": "4301",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417ab67a5c14bdce6aeb59"
+  },
+  "course_number": "4340",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417ab97a5c14bdce6aeb67"
+  },
+  "course_number": "4360",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417f867a5c14bdce6aeb9f"
+  },
+  "course_number": "3315",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f887a5c14bdce6aeba6"
+  },
+  "course_number": "3317",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f8b7a5c14bdce6aebbb"
+  },
+  "course_number": "4348",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417f9d7a5c14bdce6aebc1"
+  },
+  "course_number": "5303",
+  "subject_prefix": "MAIS"
+},{
+  "_id": {
+    "$oid": "62417f9d7a5c14bdce6aebc3"
+  },
+  "course_number": "5321",
+  "subject_prefix": "MAIS"
+},{
+  "_id": {
+    "$oid": "6241a531e0a87a87f38b1a74"
+  },
+  "course_number": "1316",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a542e0a87a87f38b1aa3"
+  },
+  "course_number": "2413",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a853e0a87a87f38b1bac"
+  },
+  "course_number": "6303",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a852e0a87a87f38b1ba8"
+  },
+  "course_number": "5390",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a84ee0a87a87f38b1b93"
+  },
+  "course_number": "3305",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a851e0a87a87f38b1ba2"
+  },
+  "course_number": "4334",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad44e0a87a87f38b1bd6"
+  },
+  "course_number": "2330",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad45e0a87a87f38b1bd9"
+  },
+  "course_number": "2340",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad49e0a87a87f38b1be8"
+  },
+  "course_number": "3120",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad4ce0a87a87f38b1bf4"
+  },
+  "course_number": "3310",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad4ee0a87a87f38b1bfd"
+  },
+  "course_number": "3350",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad59e0a87a87f38b1c27"
+  },
+  "course_number": "6300",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241b391e0a87a87f38b1d18"
+  },
+  "course_number": "3340",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b392e0a87a87f38b1d1d"
+  },
+  "course_number": "4330",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b394e0a87a87f38b1d23"
+  },
+  "course_number": "4332",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3afe0a87a87f38b1d53"
+  },
+  "course_number": "6342",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b43ae0a87a87f38b1d6c"
+  },
+  "course_number": "5361",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b852e0a87a87f38b1d9e"
+  },
+  "course_number": "2319",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b853e0a87a87f38b1da2"
+  },
+  "course_number": "2325",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b854e0a87a87f38b1da5"
+  },
+  "course_number": "2328",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b857e0a87a87f38b1db5"
+  },
+  "course_number": "3385",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b857e0a87a87f38b1db9"
+  },
+  "course_number": "3388",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241a852e0a87a87f38b1ba4"
+  },
+  "course_number": "4341",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a855e0a87a87f38b1bb9"
+  },
+  "course_number": "6342",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad47e0a87a87f38b1be2"
+  },
+  "course_number": "3115",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad4fe0a87a87f38b1c01"
+  },
+  "course_number": "3351",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad50e0a87a87f38b1c05"
+  },
+  "course_number": "3370",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad58e0a87a87f38b1c22"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5de0a87a87f38b1c39"
+  },
+  "course_number": "6351",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5de0a87a87f38b1c3b"
+  },
+  "course_number": "6354",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ae5de0a87a87f38b1c67"
+  },
+  "course_number": "2291",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6241b13ce0a87a87f38b1cc1"
+  },
+  "course_number": "6346",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b140e0a87a87f38b1ccc"
+  },
+  "course_number": "6357",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b143e0a87a87f38b1cdb"
+  },
+  "course_number": "6373",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b143e0a87a87f38b1cde"
+  },
+  "course_number": "6375",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b36be0a87a87f38b1d0d"
+  },
+  "course_number": "3320",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3a7e0a87a87f38b1d31"
+  },
+  "course_number": "4V93",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3b1e0a87a87f38b1d5f"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3b1e0a87a87f38b1d62"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b4c0e0a87a87f38b1d74"
+  },
+  "course_number": "5324",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6241b4c3e0a87a87f38b1d76"
+  },
+  "course_number": "5V06",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6241a850e0a87a87f38b1b9b"
+  },
+  "course_number": "3323",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad42e0a87a87f38b1bcd"
+  },
+  "course_number": "2310",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad46e0a87a87f38b1bde"
+  },
+  "course_number": "3105",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad4be0a87a87f38b1bee"
+  },
+  "course_number": "3150",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ce0a87a87f38b1c36"
+  },
+  "course_number": "6337",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad98e0a87a87f38b1c48"
+  },
+  "course_number": "3300",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241afcfe0a87a87f38b1c7d"
+  },
+  "course_number": "6309",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b121e0a87a87f38b1c8a"
+  },
+  "course_number": "6319",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b124e0a87a87f38b1c95"
+  },
+  "course_number": "6323",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b137e0a87a87f38b1ca8"
+  },
+  "course_number": "6330",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b13ae0a87a87f38b1cb8"
+  },
+  "course_number": "6344",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b142e0a87a87f38b1cd3"
+  },
+  "course_number": "6363",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b392e0a87a87f38b1d1b"
+  },
+  "course_number": "4320",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b395e0a87a87f38b1d2b"
+  },
+  "course_number": "4350",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3aee0a87a87f38b1d51"
+  },
+  "course_number": "6341",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b444e0a87a87f38b1d72"
+  },
+  "course_number": "6340",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b857e0a87a87f38b1db7"
+  },
+  "course_number": "3386",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241a84fe0a87a87f38b1b98"
+  },
+  "course_number": "3311",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a852e0a87a87f38b1ba6"
+  },
+  "course_number": "5301",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad4ee0a87a87f38b1bfb"
+  },
+  "course_number": "3320",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad50e0a87a87f38b1c03"
+  },
+  "course_number": "3360",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad50e0a87a87f38b1c07"
+  },
+  "course_number": "3380",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad51e0a87a87f38b1c09"
+  },
+  "course_number": "4110",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad59e0a87a87f38b1c29"
+  },
+  "course_number": "6303",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ae0a87a87f38b1c2d"
+  },
+  "course_number": "6309",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ce0a87a87f38b1c34"
+  },
+  "course_number": "6323",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ee0a87a87f38b1c42"
+  },
+  "course_number": "6375",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241adc6e0a87a87f38b1c58"
+  },
+  "course_number": "6318",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241add3e0a87a87f38b1c5f"
+  },
+  "course_number": "7312",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241ae4fe0a87a87f38b1c61"
+  },
+  "course_number": "1141",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6241ae56e0a87a87f38b1c64"
+  },
+  "course_number": "2251",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6241afcce0a87a87f38b1c73"
+  },
+  "course_number": "6302",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b120e0a87a87f38b1c84"
+  },
+  "course_number": "6316",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b132e0a87a87f38b1c9a"
+  },
+  "course_number": "6324",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b137e0a87a87f38b1cab"
+  },
+  "course_number": "6333",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b141e0a87a87f38b1cd0"
+  },
+  "course_number": "6360",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b287e0a87a87f38b1cf1"
+  },
+  "course_number": "3300",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3ace0a87a87f38b1d48"
+  },
+  "course_number": "6323",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3b0e0a87a87f38b1d5a"
+  },
+  "course_number": "6352",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b437e0a87a87f38b1d6a"
+  },
+  "course_number": "5341",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b441e0a87a87f38b1d70"
+  },
+  "course_number": "6320",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b850e0a87a87f38b1d95"
+  },
+  "course_number": "2315",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b858e0a87a87f38b1dbb"
+  },
+  "course_number": "3389",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b8e2e0a87a87f38b1dc5"
+  },
+  "course_number": "1101",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241a854e0a87a87f38b1bae"
+  },
+  "course_number": "6312",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a84ee0a87a87f38b1b95"
+  },
+  "course_number": "3310",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a84de0a87a87f38b1b8d"
+  },
+  "course_number": "2451",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a854e0a87a87f38b1bb0"
+  },
+  "course_number": "6313",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a854e0a87a87f38b1bb3"
+  },
+  "course_number": "6315",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad43e0a87a87f38b1bd1"
+  },
+  "course_number": "2320",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad4de0a87a87f38b1bf7"
+  },
+  "course_number": "3315",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad53e0a87a87f38b1c11"
+  },
+  "course_number": "4310",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad54e0a87a87f38b1c17"
+  },
+  "course_number": "4340",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad55e0a87a87f38b1c19"
+  },
+  "course_number": "4381",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad9be0a87a87f38b1c54"
+  },
+  "course_number": "6312",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241afcce0a87a87f38b1c6f"
+  },
+  "course_number": "6204",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b122e0a87a87f38b1c8f"
+  },
+  "course_number": "6320",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b138e0a87a87f38b1cae"
+  },
+  "course_number": "6334",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b139e0a87a87f38b1cb4"
+  },
+  "course_number": "6337",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b13ee0a87a87f38b1cc6"
+  },
+  "course_number": "6356",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b287e0a87a87f38b1cee"
+  },
+  "course_number": "3200",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b36ce0a87a87f38b1d10"
+  },
+  "course_number": "3330",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b395e0a87a87f38b1d29"
+  },
+  "course_number": "4338",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b398e0a87a87f38b1d2d"
+  },
+  "course_number": "4380",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3abe0a87a87f38b1d43"
+  },
+  "course_number": "6310",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3afe0a87a87f38b1d58"
+  },
+  "course_number": "6350",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b42de0a87a87f38b1d64"
+  },
+  "course_number": "5300",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b431e0a87a87f38b1d66"
+  },
+  "course_number": "5310",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b434e0a87a87f38b1d68"
+  },
+  "course_number": "5331",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b84fe0a87a87f38b1d93"
+  },
+  "course_number": "2127",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b855e0a87a87f38b1dad"
+  },
+  "course_number": "3312",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b856e0a87a87f38b1db3"
+  },
+  "course_number": "3324",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b859e0a87a87f38b1dc1"
+  },
+  "course_number": "4V12",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b8e8e0a87a87f38b1ddd"
+  },
+  "course_number": "1141",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241a853e0a87a87f38b1baa"
+  },
+  "course_number": "6301",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a855e0a87a87f38b1bb7"
+  },
+  "course_number": "6331",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad5de0a87a87f38b1c3e"
+  },
+  "course_number": "6370",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad98e0a87a87f38b1c4a"
+  },
+  "course_number": "4342",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241ae61e0a87a87f38b1c69"
+  },
+  "course_number": "3341",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6241ae64e0a87a87f38b1c6b"
+  },
+  "course_number": "4341",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6241ae67e0a87a87f38b1c6d"
+  },
+  "course_number": "4391",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6241afcde0a87a87f38b1c75"
+  },
+  "course_number": "6308",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b142e0a87a87f38b1cd6"
+  },
+  "course_number": "6364",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b143e0a87a87f38b1ce0"
+  },
+  "course_number": "6378",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b144e0a87a87f38b1ce2"
+  },
+  "course_number": "6380",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b145e0a87a87f38b1ce7"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b394e0a87a87f38b1d21"
+  },
+  "course_number": "4331",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b395e0a87a87f38b1d26"
+  },
+  "course_number": "4334",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3ace0a87a87f38b1d46"
+  },
+  "course_number": "6321",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3b0e0a87a87f38b1d5d"
+  },
+  "course_number": "6380",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b43ee0a87a87f38b1d6e"
+  },
+  "course_number": "6319",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241b852e0a87a87f38b1da0"
+  },
+  "course_number": "2322",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b854e0a87a87f38b1da9"
+  },
+  "course_number": "3118",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241a84ee0a87a87f38b1b91"
+  },
+  "course_number": "3303",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a850e0a87a87f38b1b9d"
+  },
+  "course_number": "3379",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a850e0a87a87f38b1b9f"
+  },
+  "course_number": "4301",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241a855e0a87a87f38b1bb5"
+  },
+  "course_number": "6319",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241ad3de0a87a87f38b1bbd"
+  },
+  "course_number": "1100",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad40e0a87a87f38b1bc4"
+  },
+  "course_number": "1208",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad40e0a87a87f38b1bc7"
+  },
+  "course_number": "2120",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad4ce0a87a87f38b1bf1"
+  },
+  "course_number": "3305",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad54e0a87a87f38b1c14"
+  },
+  "course_number": "4320",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad59e0a87a87f38b1c25"
+  },
+  "course_number": "5370",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ae0a87a87f38b1c2b"
+  },
+  "course_number": "6306",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ee0a87a87f38b1c40"
+  },
+  "course_number": "6374",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5fe0a87a87f38b1c46"
+  },
+  "course_number": "7392",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad99e0a87a87f38b1c4c"
+  },
+  "course_number": "6303",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241adc8e0a87a87f38b1c5a"
+  },
+  "course_number": "6352",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241add0e0a87a87f38b1c5d"
+  },
+  "course_number": "6360",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6241b121e0a87a87f38b1c88"
+  },
+  "course_number": "6317",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b135e0a87a87f38b1ca1"
+  },
+  "course_number": "6326",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b139e0a87a87f38b1cb6"
+  },
+  "course_number": "6338",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b13be0a87a87f38b1cbd"
+  },
+  "course_number": "6345",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b142e0a87a87f38b1cd8"
+  },
+  "course_number": "6369",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b3a7e0a87a87f38b1d34"
+  },
+  "course_number": "6301",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3abe0a87a87f38b1d41"
+  },
+  "course_number": "6309",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3aee0a87a87f38b1d4f"
+  },
+  "course_number": "6338",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3afe0a87a87f38b1d56"
+  },
+  "course_number": "6343",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b851e0a87a87f38b1d9a"
+  },
+  "course_number": "2317",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b855e0a87a87f38b1daf"
+  },
+  "course_number": "3316",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b859e0a87a87f38b1dbf"
+  },
+  "course_number": "4348",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241ad53e0a87a87f38b1c0f"
+  },
+  "course_number": "4301",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5be0a87a87f38b1c2f"
+  },
+  "course_number": "6312",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5be0a87a87f38b1c32"
+  },
+  "course_number": "6318",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241ad5ee0a87a87f38b1c44"
+  },
+  "course_number": "7100",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241b146e0a87a87f38b1cea"
+  },
+  "course_number": "7220",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b146e0a87a87f38b1cec"
+  },
+  "course_number": "7420",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241b3ade0a87a87f38b1d4a"
+  },
+  "course_number": "6330",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b3ade0a87a87f38b1d4c"
+  },
+  "course_number": "6337",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241b84de0a87a87f38b1d8a"
+  },
+  "course_number": "1306",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b84fe0a87a87f38b1d91"
+  },
+  "course_number": "2113",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b855e0a87a87f38b1dab"
+  },
+  "course_number": "3120",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b856e0a87a87f38b1db1"
+  },
+  "course_number": "3322",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b858e0a87a87f38b1dbd"
+  },
+  "course_number": "4345",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241b8ebe0a87a87f38b1de7"
+  },
+  "course_number": "1311",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b8ede0a87a87f38b1def"
+  },
+  "course_number": "3343",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b8efe0a87a87f38b1dfa"
+  },
+  "course_number": "4694",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b8ece0a87a87f38b1deb"
+  },
+  "course_number": "3341",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b8eee0a87a87f38b1df8"
+  },
+  "course_number": "4390",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b949e0a87a87f38b1dfe"
+  },
+  "course_number": "3344",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b94ae0a87a87f38b1e00"
+  },
+  "course_number": "3361",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b950e0a87a87f38b1e1d"
+  },
+  "course_number": "4366",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241bea7e0a87a87f38b1e91"
+  },
+  "course_number": "4310",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb1e0a87a87f38b1eb5"
+  },
+  "course_number": "6332",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb7e0a87a87f38b1ed0"
+  },
+  "course_number": "6371",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bebce0a87a87f38b1ee4"
+  },
+  "course_number": "6398",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf9be0a87a87f38b1f20"
+  },
+  "course_number": "6321",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfc5e0a87a87f38b1f24"
+  },
+  "course_number": "6348",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c5b7e0a87a87f38b1f61"
+  },
+  "course_number": "2125",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c67ee0a87a87f38b1fe8"
+  },
+  "course_number": "3310",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c67fe0a87a87f38b1fec"
+  },
+  "course_number": "3325",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71ce0a87a87f38b2021"
+  },
+  "course_number": "6335",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71ce0a87a87f38b2023"
+  },
+  "course_number": "6350",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241b8ede0a87a87f38b1df3"
+  },
+  "course_number": "4141",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b8eee0a87a87f38b1df6"
+  },
+  "course_number": "4341",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b8efe0a87a87f38b1dfc"
+  },
+  "course_number": "4696",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b94fe0a87a87f38b1e13"
+  },
+  "course_number": "4356",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241ba14e0a87a87f38b1e33"
+  },
+  "course_number": "6332",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6241bab1e0a87a87f38b1e38"
+  },
+  "course_number": "3310",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241bb28e0a87a87f38b1e4d"
+  },
+  "course_number": "4300",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241bb29e0a87a87f38b1e50"
+  },
+  "course_number": "4310",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241be60e0a87a87f38b1e6e"
+  },
+  "course_number": "3320",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bea8e0a87a87f38b1e96"
+  },
+  "course_number": "4350",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beaee0a87a87f38b1eaa"
+  },
+  "course_number": "6302",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb3e0a87a87f38b1ebb"
+  },
+  "course_number": "6335",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb3e0a87a87f38b1ebd"
+  },
+  "course_number": "6341",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bec0e0a87a87f38b1ef0"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bec1e0a87a87f38b1ef8"
+  },
+  "course_number": "7051",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf5fe0a87a87f38b1f10"
+  },
+  "course_number": "3381",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c05ce0a87a87f38b1f3a"
+  },
+  "course_number": "2303",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6241c0e8e0a87a87f38b1f45"
+  },
+  "course_number": "1121",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "6241c5b6e0a87a87f38b1f5a"
+  },
+  "course_number": "1100",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5c0e0a87a87f38b1f78"
+  },
+  "course_number": "2126",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5cee0a87a87f38b1fa4"
+  },
+  "course_number": "3330",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d3e0a87a87f38b1fbb"
+  },
+  "course_number": "5311",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c691e0a87a87f38b1ff8"
+  },
+  "course_number": "4329",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c6d9e0a87a87f38b2009"
+  },
+  "course_number": "4376",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241bcdee0a87a87f38b1e58"
+  },
+  "course_number": "3310",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb4e0a87a87f38b1ec2"
+  },
+  "course_number": "6364",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf5ae0a87a87f38b1f0a"
+  },
+  "course_number": "3378",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf63e0a87a87f38b1f12"
+  },
+  "course_number": "4351",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf9ce0a87a87f38b1f22"
+  },
+  "course_number": "6345",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfd0e0a87a87f38b1f2a"
+  },
+  "course_number": "6399",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfd1e0a87a87f38b1f2c"
+  },
+  "course_number": "7306",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c065e0a87a87f38b1f40"
+  },
+  "course_number": "4340",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6241c5b6e0a87a87f38b1f5c"
+  },
+  "course_number": "1301",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d1e0a87a87f38b1fb3"
+  },
+  "course_number": "4390",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d1e0a87a87f38b1fb5"
+  },
+  "course_number": "4V11",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d2e0a87a87f38b1fb9"
+  },
+  "course_number": "5301",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d4e0a87a87f38b1fc1"
+  },
+  "course_number": "5322",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d4e0a87a87f38b1fc3"
+  },
+  "course_number": "5331",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d5e0a87a87f38b1fc8"
+  },
+  "course_number": "5V48",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c603e0a87a87f38b1fce"
+  },
+  "course_number": "6301",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c604e0a87a87f38b1fd4"
+  },
+  "course_number": "6335",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c605e0a87a87f38b1fd8"
+  },
+  "course_number": "6351",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c606e0a87a87f38b1fe0"
+  },
+  "course_number": "6V81",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c6cfe0a87a87f38b2004"
+  },
+  "course_number": "4372",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71ae0a87a87f38b2013"
+  },
+  "course_number": "4V66",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71be0a87a87f38b2019"
+  },
+  "course_number": "4V76",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71be0a87a87f38b201d"
+  },
+  "course_number": "6316",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71ce0a87a87f38b201f"
+  },
+  "course_number": "6324",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241b8eae0a87a87f38b1de4"
+  },
+  "course_number": "1143",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b94ce0a87a87f38b1e07"
+  },
+  "course_number": "4350",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b8ece0a87a87f38b1de9"
+  },
+  "course_number": "2330",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6241b950e0a87a87f38b1e1b"
+  },
+  "course_number": "4363",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b952e0a87a87f38b1e25"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241bb27e0a87a87f38b1e4a"
+  },
+  "course_number": "3330",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241bea1e0a87a87f38b1e83"
+  },
+  "course_number": "3360",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb1e0a87a87f38b1eb3"
+  },
+  "course_number": "6303",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bebae0a87a87f38b1edc"
+  },
+  "course_number": "6393",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bebce0a87a87f38b1ee2"
+  },
+  "course_number": "6394",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bec2e0a87a87f38b1efa"
+  },
+  "course_number": "7310",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf56e0a87a87f38b1f00"
+  },
+  "course_number": "3306",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf57e0a87a87f38b1f03"
+  },
+  "course_number": "3310",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfd1e0a87a87f38b1f2e"
+  },
+  "course_number": "7320",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c04fe0a87a87f38b1f33"
+  },
+  "course_number": "1301",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6241c5cfe0a87a87f38b1fa9"
+  },
+  "course_number": "3411",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d0e0a87a87f38b1fad"
+  },
+  "course_number": "4301",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d3e0a87a87f38b1fbd"
+  },
+  "course_number": "5315",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d4e0a87a87f38b1fc6"
+  },
+  "course_number": "5376",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c604e0a87a87f38b1fd2"
+  },
+  "course_number": "6329",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c606e0a87a87f38b1fde"
+  },
+  "course_number": "6359",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c680e0a87a87f38b1ff6"
+  },
+  "course_number": "4320",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c6a8e0a87a87f38b1fff"
+  },
+  "course_number": "4348",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c6d1e0a87a87f38b2007"
+  },
+  "course_number": "4373",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71de0a87a87f38b2025"
+  },
+  "course_number": "6351",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241b951e0a87a87f38b1e1f"
+  },
+  "course_number": "4373",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b952e0a87a87f38b1e23"
+  },
+  "course_number": "4394",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241ba0ee0a87a87f38b1e2e"
+  },
+  "course_number": "6303",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6241be68e0a87a87f38b1e70"
+  },
+  "course_number": "3330",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241be73e0a87a87f38b1e73"
+  },
+  "course_number": "3333",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bea7e0a87a87f38b1e93"
+  },
+  "course_number": "4330",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb5e0a87a87f38b1ec7"
+  },
+  "course_number": "6367",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bec1e0a87a87f38b1ef4"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf57e0a87a87f38b1f05"
+  },
+  "course_number": "3333",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf8de0a87a87f38b1f1a"
+  },
+  "course_number": "6311",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c5b6e0a87a87f38b1f5e"
+  },
+  "course_number": "1302",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5cbe0a87a87f38b1f99"
+  },
+  "course_number": "2325",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5cfe0a87a87f38b1fa7"
+  },
+  "course_number": "3380",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c71de0a87a87f38b2027"
+  },
+  "course_number": "7381",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241b94ce0a87a87f38b1e09"
+  },
+  "course_number": "4352",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b951e0a87a87f38b1e21"
+  },
+  "course_number": "4385",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241ba01e0a87a87f38b1e29"
+  },
+  "course_number": "6301",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6241bb2ae0a87a87f38b1e52"
+  },
+  "course_number": "4334",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241bb2ae0a87a87f38b1e54"
+  },
+  "course_number": "4335",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241bea8e0a87a87f38b1e99"
+  },
+  "course_number": "6301",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb9e0a87a87f38b1ed6"
+  },
+  "course_number": "6379",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf5de0a87a87f38b1f0d"
+  },
+  "course_number": "3380",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf96e0a87a87f38b1f1e"
+  },
+  "course_number": "6320",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfd0e0a87a87f38b1f28"
+  },
+  "course_number": "6387",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c0ede0a87a87f38b1f48"
+  },
+  "course_number": "2125",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "6241c5d0e0a87a87f38b1faf"
+  },
+  "course_number": "4352",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d1e0a87a87f38b1fb1"
+  },
+  "course_number": "4373",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5dae0a87a87f38b1fcc"
+  },
+  "course_number": "4302",
+  "subject_prefix": "PPOL"
+},{
+  "_id": {
+    "$oid": "6241c604e0a87a87f38b1fd6"
+  },
+  "course_number": "6350",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c680e0a87a87f38b1ff2"
+  },
+  "course_number": "3351",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c680e0a87a87f38b1ff4"
+  },
+  "course_number": "4302",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c69ce0a87a87f38b1ffd"
+  },
+  "course_number": "4344",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241b94de0a87a87f38b1e0c"
+  },
+  "course_number": "4353",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b94ee0a87a87f38b1e11"
+  },
+  "course_number": "4354",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b94fe0a87a87f38b1e15"
+  },
+  "course_number": "4359",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241b950e0a87a87f38b1e18"
+  },
+  "course_number": "4362",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241ba1be0a87a87f38b1e36"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6241beb4e0a87a87f38b1ebf"
+  },
+  "course_number": "6362",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb5e0a87a87f38b1ec4"
+  },
+  "course_number": "6366",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb6e0a87a87f38b1eca"
+  },
+  "course_number": "6369",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb7e0a87a87f38b1ecd"
+  },
+  "course_number": "6370",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241beb9e0a87a87f38b1ed8"
+  },
+  "course_number": "6390",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bec2e0a87a87f38b1efc"
+  },
+  "course_number": "7353",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf90e0a87a87f38b1f1c"
+  },
+  "course_number": "6313",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfcee0a87a87f38b1f26"
+  },
+  "course_number": "6382",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bfd1e0a87a87f38b1f31"
+  },
+  "course_number": "7330",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c5cbe0a87a87f38b1f97"
+  },
+  "course_number": "2303",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5cce0a87a87f38b1f9d"
+  },
+  "course_number": "2326",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5cfe0a87a87f38b1fab"
+  },
+  "course_number": "3416",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d3e0a87a87f38b1fbf"
+  },
+  "course_number": "5319",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c5d5e0a87a87f38b1fca"
+  },
+  "course_number": "6300",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c605e0a87a87f38b1fda"
+  },
+  "course_number": "6352",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c67fe0a87a87f38b1ff0"
+  },
+  "course_number": "3350",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c6abe0a87a87f38b2001"
+  },
+  "course_number": "4370",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71ae0a87a87f38b2016"
+  },
+  "course_number": "4V67",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c71be0a87a87f38b201b"
+  },
+  "course_number": "6311",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241ba11e0a87a87f38b1e31"
+  },
+  "course_number": "6331",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6241bb2be0a87a87f38b1e56"
+  },
+  "course_number": "4352",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241beb8e0a87a87f38b1ed4"
+  },
+  "course_number": "6377",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bebee0a87a87f38b1ee9"
+  },
+  "course_number": "6399",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241bf56e0a87a87f38b1efe"
+  },
+  "course_number": "2325",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf57e0a87a87f38b1f08"
+  },
+  "course_number": "3377",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf88e0a87a87f38b1f14"
+  },
+  "course_number": "4355",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241bf88e0a87a87f38b1f17"
+  },
+  "course_number": "4370",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241c05fe0a87a87f38b1f3c"
+  },
+  "course_number": "2316",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6241c061e0a87a87f38b1f3e"
+  },
+  "course_number": "3321",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6241c0e3e0a87a87f38b1f42"
+  },
+  "course_number": "1120",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "6241c5cee0a87a87f38b1fa2"
+  },
+  "course_number": "2422",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241c603e0a87a87f38b1fd0"
+  },
+  "course_number": "6310",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c605e0a87a87f38b1fdc"
+  },
+  "course_number": "6354",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c606e0a87a87f38b1fe3"
+  },
+  "course_number": "8398",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241c67ee0a87a87f38b1fe5"
+  },
+  "course_number": "3303",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c67ee0a87a87f38b1fea"
+  },
+  "course_number": "3322",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c67fe0a87a87f38b1fee"
+  },
+  "course_number": "3328",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c699e0a87a87f38b1ffa"
+  },
+  "course_number": "4331",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c6dce0a87a87f38b200b"
+  },
+  "course_number": "4396",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241c9f1e0a87a87f38b2065"
+  },
+  "course_number": "3332",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9abe0a87a87f38b204b"
+  },
+  "course_number": "2301",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9efe0a87a87f38b205a"
+  },
+  "course_number": "3100",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f4e0a87a87f38b2072"
+  },
+  "course_number": "3360",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fce0a87a87f38b208f"
+  },
+  "course_number": "4332",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fde0a87a87f38b2099"
+  },
+  "course_number": "4346",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca00e0a87a87f38b20a4"
+  },
+  "course_number": "4385",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca8ce0a87a87f38b20b4"
+  },
+  "course_number": "6338",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241cc61e0a87a87f38b20cd"
+  },
+  "course_number": "1302",
+  "subject_prefix": "RHET"
+},{
+  "_id": {
+    "$oid": "6241d077e0a87a87f38b2121"
+  },
+  "course_number": "5V06",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241d166e0a87a87f38b2167"
+  },
+  "course_number": "6329",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1c8e0a87a87f38b2185"
+  },
+  "course_number": "3315",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cbe0a87a87f38b2198"
+  },
+  "course_number": "4371",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d21ee0a87a87f38b21b6"
+  },
+  "course_number": "2341",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d2f6e0a87a87f38b21d3"
+  },
+  "course_number": "4394",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241c9ede0a87a87f38b2052"
+  },
+  "course_number": "2314",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241d3cde0a87a87f38b21ea"
+  },
+  "course_number": "3360",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d403e0a87a87f38b21f6"
+  },
+  "course_number": "6337",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241c9ede0a87a87f38b2054"
+  },
+  "course_number": "2317",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241d6d1e0a87a87f38b221a"
+  },
+  "course_number": "6308",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241c9f2e0a87a87f38b2069"
+  },
+  "course_number": "3339",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241d70fe0a87a87f38b2255"
+  },
+  "course_number": "6337",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d712e0a87a87f38b225d"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241df97e0a87a87f38b2274"
+  },
+  "course_number": "2371",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241c9f4e0a87a87f38b2070"
+  },
+  "course_number": "3355",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f5e0a87a87f38b2077"
+  },
+  "course_number": "3362",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fae0a87a87f38b2089"
+  },
+  "course_number": "4324",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca00e0a87a87f38b20a8"
+  },
+  "course_number": "4394",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca01e0a87a87f38b20aa"
+  },
+  "course_number": "4395",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241cabde0a87a87f38b20be"
+  },
+  "course_number": "6395",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241d076e0a87a87f38b211b"
+  },
+  "course_number": "5326",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241d159e0a87a87f38b213c"
+  },
+  "course_number": "3345",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d15ee0a87a87f38b2148"
+  },
+  "course_number": "3377",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d161e0a87a87f38b2152"
+  },
+  "course_number": "4348",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1c9e0a87a87f38b2190"
+  },
+  "course_number": "3343",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d221e0a87a87f38b21b8"
+  },
+  "course_number": "3365",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d2aee0a87a87f38b21be"
+  },
+  "course_number": "3303",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2c3e0a87a87f38b21cc"
+  },
+  "course_number": "3390",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2f6e0a87a87f38b21d5"
+  },
+  "course_number": "4395",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d385e0a87a87f38b21dc"
+  },
+  "course_number": "2332",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d3b8e0a87a87f38b21e8"
+  },
+  "course_number": "3355",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d404e0a87a87f38b21f8"
+  },
+  "course_number": "6341",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d404e0a87a87f38b21fa"
+  },
+  "course_number": "6344",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d5c1e0a87a87f38b2204"
+  },
+  "course_number": "6303",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d6d1e0a87a87f38b2218"
+  },
+  "course_number": "6307",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d6d2e0a87a87f38b221e"
+  },
+  "course_number": "6311",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d704e0a87a87f38b222e"
+  },
+  "course_number": "6318",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d709e0a87a87f38b2240"
+  },
+  "course_number": "6320",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d70ce0a87a87f38b224b"
+  },
+  "course_number": "6334",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241df95e0a87a87f38b226d"
+  },
+  "course_number": "1310",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241ca01e0a87a87f38b20ac"
+  },
+  "course_number": "4V99",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9ffe0a87a87f38b20a2"
+  },
+  "course_number": "4377",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca87e0a87a87f38b20b2"
+  },
+  "course_number": "6330",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241ca8fe0a87a87f38b20b6"
+  },
+  "course_number": "6346",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241d164e0a87a87f38b215e"
+  },
+  "course_number": "4485",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d16ae0a87a87f38b2177"
+  },
+  "course_number": "8V07",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1cde0a87a87f38b21a5"
+  },
+  "course_number": "6344",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d5c1e0a87a87f38b2202"
+  },
+  "course_number": "6301",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d703e0a87a87f38b2229"
+  },
+  "course_number": "6313",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241ca7fe0a87a87f38b20ae"
+  },
+  "course_number": "6312",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241cb3fe0a87a87f38b20c1"
+  },
+  "course_number": "3305",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241cda8e0a87a87f38b2115"
+  },
+  "course_number": "4331",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "6241d169e0a87a87f38b2173"
+  },
+  "course_number": "7301",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d16ee0a87a87f38b2179"
+  },
+  "course_number": "5303",
+  "subject_prefix": "SMED"
+},{
+  "_id": {
+    "$oid": "6241d1c8e0a87a87f38b2182"
+  },
+  "course_number": "3305",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1c9e0a87a87f38b218d"
+  },
+  "course_number": "3342",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cde0a87a87f38b21a1"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cee0a87a87f38b21a9"
+  },
+  "course_number": "6381",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d2b7e0a87a87f38b21c3"
+  },
+  "course_number": "3342",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2b9e0a87a87f38b21c5"
+  },
+  "course_number": "3343",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2ece0a87a87f38b21cf"
+  },
+  "course_number": "4308",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d403e0a87a87f38b21f4"
+  },
+  "course_number": "6331",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d6c7e0a87a87f38b2214"
+  },
+  "course_number": "6304",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d70ae0a87a87f38b2242"
+  },
+  "course_number": "6326",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d70be0a87a87f38b2246"
+  },
+  "course_number": "6333",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241c9f1e0a87a87f38b2062"
+  },
+  "course_number": "3331",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f6e0a87a87f38b207a"
+  },
+  "course_number": "3392",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f7e0a87a87f38b207e"
+  },
+  "course_number": "3393",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fae0a87a87f38b2087"
+  },
+  "course_number": "4323",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fee0a87a87f38b209d"
+  },
+  "course_number": "4347",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241cb4de0a87a87f38b20c7"
+  },
+  "course_number": "6321",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241d157e0a87a87f38b2136"
+  },
+  "course_number": "3341",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d15be0a87a87f38b2142"
+  },
+  "course_number": "3354",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d168e0a87a87f38b216d"
+  },
+  "course_number": "6367",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1c6e0a87a87f38b217b"
+  },
+  "course_number": "1301",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1c7e0a87a87f38b2180"
+  },
+  "course_number": "2300",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1c9e0a87a87f38b218a"
+  },
+  "course_number": "3331",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cae0a87a87f38b2196"
+  },
+  "course_number": "4369",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cce0a87a87f38b219d"
+  },
+  "course_number": "4385",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cce0a87a87f38b219f"
+  },
+  "course_number": "4388",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d224e0a87a87f38b21ba"
+  },
+  "course_number": "4364",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d2afe0a87a87f38b21c0"
+  },
+  "course_number": "3341",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2c0e0a87a87f38b21c9"
+  },
+  "course_number": "3388",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d389e0a87a87f38b21e2"
+  },
+  "course_number": "3341",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d405e0a87a87f38b21fe"
+  },
+  "course_number": "6390",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d6d1e0a87a87f38b2216"
+  },
+  "course_number": "6305",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d70ae0a87a87f38b2244"
+  },
+  "course_number": "6332",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241df97e0a87a87f38b2272"
+  },
+  "course_number": "1351",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241df98e0a87a87f38b2276"
+  },
+  "course_number": "2372",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241df98e0a87a87f38b2279"
+  },
+  "course_number": "3310",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241c9efe0a87a87f38b205c"
+  },
+  "course_number": "3310",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f0e0a87a87f38b2060"
+  },
+  "course_number": "3324",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f2e0a87a87f38b2067"
+  },
+  "course_number": "3333",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fbe0a87a87f38b208b"
+  },
+  "course_number": "4328",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fde0a87a87f38b2097"
+  },
+  "course_number": "4344",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fee0a87a87f38b209f"
+  },
+  "course_number": "4359",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca93e0a87a87f38b20b8"
+  },
+  "course_number": "6350",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241ca99e0a87a87f38b20bc"
+  },
+  "course_number": "6376",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241d075e0a87a87f38b2119"
+  },
+  "course_number": "5322",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241d076e0a87a87f38b211f"
+  },
+  "course_number": "5340",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241d155e0a87a87f38b2130"
+  },
+  "course_number": "3340",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d15fe0a87a87f38b214d"
+  },
+  "course_number": "4347",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d164e0a87a87f38b215c"
+  },
+  "course_number": "4367",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d167e0a87a87f38b2169"
+  },
+  "course_number": "6356",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d168e0a87a87f38b2171"
+  },
+  "course_number": "6388",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1cae0a87a87f38b2194"
+  },
+  "course_number": "4302",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cbe0a87a87f38b219a"
+  },
+  "course_number": "4372",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cde0a87a87f38b21a3"
+  },
+  "course_number": "6341",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cee0a87a87f38b21a7"
+  },
+  "course_number": "6350",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d21be0a87a87f38b21b4"
+  },
+  "course_number": "2312",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d2bde0a87a87f38b21c7"
+  },
+  "course_number": "3344",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2f6e0a87a87f38b21d7"
+  },
+  "course_number": "4396",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d385e0a87a87f38b21d9"
+  },
+  "course_number": "1342",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d404e0a87a87f38b21fc"
+  },
+  "course_number": "6348",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d6d2e0a87a87f38b221c"
+  },
+  "course_number": "6310",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d703e0a87a87f38b222c"
+  },
+  "course_number": "6316",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241c9f3e0a87a87f38b206c"
+  },
+  "course_number": "3342",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f4e0a87a87f38b2074"
+  },
+  "course_number": "3361",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fbe0a87a87f38b208d"
+  },
+  "course_number": "4331",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca00e0a87a87f38b20a6"
+  },
+  "course_number": "4386",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241ca96e0a87a87f38b20ba"
+  },
+  "course_number": "6357",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241cb53e0a87a87f38b20cb"
+  },
+  "course_number": "6326",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241cdabe0a87a87f38b2117"
+  },
+  "course_number": "4334",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "6241d076e0a87a87f38b211d"
+  },
+  "course_number": "5331",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241d152e0a87a87f38b2126"
+  },
+  "course_number": "3162",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d163e0a87a87f38b2158"
+  },
+  "course_number": "4351",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d164e0a87a87f38b2161"
+  },
+  "course_number": "6301",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d167e0a87a87f38b216b"
+  },
+  "course_number": "6362",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1e9e0a87a87f38b21ab"
+  },
+  "course_number": "1311",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d1eae0a87a87f38b21b1"
+  },
+  "course_number": "2311",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d3fde0a87a87f38b21ed"
+  },
+  "course_number": "4351",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d402e0a87a87f38b21f1"
+  },
+  "course_number": "6313",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d481e0a87a87f38b2200"
+  },
+  "course_number": "6323",
+  "subject_prefix": "SYSE"
+},{
+  "_id": {
+    "$oid": "6241c888e0a87a87f38b2029"
+  },
+  "course_number": "1100",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9eee0a87a87f38b2058"
+  },
+  "course_number": "2364",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9f3e0a87a87f38b206e"
+  },
+  "course_number": "3350",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241c9fce0a87a87f38b2092"
+  },
+  "course_number": "4343",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241cb4ae0a87a87f38b20c5"
+  },
+  "course_number": "3365",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241cb50e0a87a87f38b20c9"
+  },
+  "course_number": "6322",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241cda2e0a87a87f38b2112"
+  },
+  "course_number": "3370",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "6241d077e0a87a87f38b2123"
+  },
+  "course_number": "5V08",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241d154e0a87a87f38b212e"
+  },
+  "course_number": "3306",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d163e0a87a87f38b215a"
+  },
+  "course_number": "4352",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d168e0a87a87f38b216f"
+  },
+  "course_number": "6387",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241d1c8e0a87a87f38b2188"
+  },
+  "course_number": "3321",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1cae0a87a87f38b2192"
+  },
+  "course_number": "3381",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241d1eae0a87a87f38b21af"
+  },
+  "course_number": "1312",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241d2abe0a87a87f38b21bc"
+  },
+  "course_number": "3301",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d2f4e0a87a87f38b21d1"
+  },
+  "course_number": "4386",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241d402e0a87a87f38b21ef"
+  },
+  "course_number": "5351",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241d6d3e0a87a87f38b2221"
+  },
+  "course_number": "6312",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d707e0a87a87f38b2239"
+  },
+  "course_number": "6319",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241d70fe0a87a87f38b2253"
+  },
+  "course_number": "6335",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241df99e0a87a87f38b2280"
+  },
+  "course_number": "3352",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241df99e0a87a87f38b227c"
+  },
+  "course_number": "3323",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241e07be0a87a87f38b22b2"
+  },
+  "course_number": "4V96",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "62410c40217d3d0a63f72fbe"
+  },
+  "course_number": "4304",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410cd1217d3d0a63f72fc8"
+  },
+  "course_number": "1040",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410da1217d3d0a63f72fde"
+  },
+  "course_number": "1303",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "624118018f1108457d004b4e"
+  },
+  "course_number": "3302",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "624118ce8f1108457d004ba7"
+  },
+  "course_number": "4366",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411adc0cef69f0ebc9c044"
+  },
+  "course_number": "7321",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241216e0cef69f0ebc9c110"
+  },
+  "course_number": "4310",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121710cef69f0ebc9c128"
+  },
+  "course_number": "4V01",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121760cef69f0ebc9c14d"
+  },
+  "course_number": "6384",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121770cef69f0ebc9c158"
+  },
+  "course_number": "6V95",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624124fe0cef69f0ebc9c1c4"
+  },
+  "course_number": "6382",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c470cef69f0ebc9c2b8"
+  },
+  "course_number": "4370",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412c830cef69f0ebc9c2ce"
+  },
+  "course_number": "6303",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412c840cef69f0ebc9c2d6"
+  },
+  "course_number": "6324",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624135710cef69f0ebc9c403"
+  },
+  "course_number": "7221",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136e90cef69f0ebc9c48a"
+  },
+  "course_number": "6315",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624137810cef69f0ebc9c4a2"
+  },
+  "course_number": "3308",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "624146670cef69f0ebc9c55f"
+  },
+  "course_number": "4386",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a20cef69f0ebc9c5a0"
+  },
+  "course_number": "6347",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241df9ae0a87a87f38b2284"
+  },
+  "course_number": "4301",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241e000e0a87a87f38b2286"
+  },
+  "course_number": "1010",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "62410a64217d3d0a63f72ef2"
+  },
+  "course_number": "3322",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b4a217d3d0a63f72f97"
+  },
+  "course_number": "6310",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410c3c217d3d0a63f72fbc"
+  },
+  "course_number": "4301",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410cef217d3d0a63f72fd2"
+  },
+  "course_number": "2920",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "624118228f1108457d004b61"
+  },
+  "course_number": "2340",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "62411adb0cef69f0ebc9c040"
+  },
+  "course_number": "7280",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411adc0cef69f0ebc9c046"
+  },
+  "course_number": "7351",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411af50cef69f0ebc9c04e"
+  },
+  "course_number": "3100",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "6241216c0cef69f0ebc9c108"
+  },
+  "course_number": "3520",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241216e0cef69f0ebc9c112"
+  },
+  "course_number": "4345",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121750cef69f0ebc9c143"
+  },
+  "course_number": "6351",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412c870cef69f0ebc9c2e9"
+  },
+  "course_number": "6380",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412d490cef69f0ebc9c302"
+  },
+  "course_number": "4312",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "6241310d0cef69f0ebc9c36e"
+  },
+  "course_number": "2324",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624131160cef69f0ebc9c39c"
+  },
+  "course_number": "6383",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624135060cef69f0ebc9c3c6"
+  },
+  "course_number": "3305",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "624135700cef69f0ebc9c3fa"
+  },
+  "course_number": "6377",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135710cef69f0ebc9c405"
+  },
+  "course_number": "7301",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135720cef69f0ebc9c40c"
+  },
+  "course_number": "7306",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136260cef69f0ebc9c44a"
+  },
+  "course_number": "3352",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6241369f0cef69f0ebc9c473"
+  },
+  "course_number": "3312",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624146160cef69f0ebc9c553"
+  },
+  "course_number": "4353",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146690cef69f0ebc9c56a"
+  },
+  "course_number": "4396",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a10cef69f0ebc9c595"
+  },
+  "course_number": "6324",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a80cef69f0ebc9c5c3"
+  },
+  "course_number": "6374",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241df9ae0a87a87f38b2282"
+  },
+  "course_number": "3372",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241e06de0a87a87f38b22ac"
+  },
+  "course_number": "4174",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "62410aac217d3d0a63f72f8a"
+  },
+  "course_number": "6384",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b4a217d3d0a63f72f99"
+  },
+  "course_number": "6313",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410dad217d3d0a63f72fe4"
+  },
+  "course_number": "3316",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "6241180d8f1108457d004b5f"
+  },
+  "course_number": "2311",
+  "subject_prefix": "ARAB"
+},{
+  "_id": {
+    "$oid": "62411ada0cef69f0ebc9c035"
+  },
+  "course_number": "6318",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411adc0cef69f0ebc9c049"
+  },
+  "course_number": "7353",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "624121460cef69f0ebc9c0e8"
+  },
+  "course_number": "3370",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241216d0cef69f0ebc9c10e"
+  },
+  "course_number": "3V84",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121720cef69f0ebc9c132"
+  },
+  "course_number": "5410",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121740cef69f0ebc9c13b"
+  },
+  "course_number": "6315",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121740cef69f0ebc9c141"
+  },
+  "course_number": "6337",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121760cef69f0ebc9c14b"
+  },
+  "course_number": "6360",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624124f60cef69f0ebc9c18f"
+  },
+  "course_number": "3150",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624124fd0cef69f0ebc9c1b5"
+  },
+  "course_number": "6302",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624124fe0cef69f0ebc9c1bb"
+  },
+  "course_number": "6355",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624124ff0cef69f0ebc9c1c6"
+  },
+  "course_number": "6388",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624125010cef69f0ebc9c1d4"
+  },
+  "course_number": "7V87",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624125d60cef69f0ebc9c1eb"
+  },
+  "course_number": "6311",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "624130fe0cef69f0ebc9c33b"
+  },
+  "course_number": "1116",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241310b0cef69f0ebc9c368"
+  },
+  "course_number": "2128",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624131140cef69f0ebc9c38f"
+  },
+  "course_number": "4473",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241356e0cef69f0ebc9c3ed"
+  },
+  "course_number": "6222",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135700cef69f0ebc9c3fc"
+  },
+  "course_number": "6378",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136260cef69f0ebc9c44c"
+  },
+  "course_number": "4340",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "624136b00cef69f0ebc9c47f"
+  },
+  "course_number": "4323",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241469c0cef69f0ebc9c578"
+  },
+  "course_number": "5390",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a80cef69f0ebc9c5c1"
+  },
+  "course_number": "6371",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241e002e0a87a87f38b228f"
+  },
+  "course_number": "1100",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "6241e02de0a87a87f38b2296"
+  },
+  "course_number": "2114",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "6241e06be0a87a87f38b22aa"
+  },
+  "course_number": "4074",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "62410b4a217d3d0a63f72f95"
+  },
+  "course_number": "6160",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410bbf217d3d0a63f72fb8"
+  },
+  "course_number": "6V72",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410bbf217d3d0a63f72fba"
+  },
+  "course_number": "7343",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "624118cf8f1108457d004bab"
+  },
+  "course_number": "4372",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411adb0cef69f0ebc9c03b"
+  },
+  "course_number": "7182",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "624120310cef69f0ebc9c0e1"
+  },
+  "course_number": "3351",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121710cef69f0ebc9c123"
+  },
+  "course_number": "4461",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121720cef69f0ebc9c12d"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121750cef69f0ebc9c147"
+  },
+  "course_number": "6353",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62412c810cef69f0ebc9c2ca"
+  },
+  "course_number": "6302",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412c860cef69f0ebc9c2e4"
+  },
+  "course_number": "6367",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624131110cef69f0ebc9c37d"
+  },
+  "course_number": "3322",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624131140cef69f0ebc9c38b"
+  },
+  "course_number": "3V92",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624131160cef69f0ebc9c39e"
+  },
+  "course_number": "6V79",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624131170cef69f0ebc9c3a0"
+  },
+  "course_number": "8398",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241356f0cef69f0ebc9c3f2"
+  },
+  "course_number": "6307",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135710cef69f0ebc9c407"
+  },
+  "course_number": "7302",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135730cef69f0ebc9c418"
+  },
+  "course_number": "7V86",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136270cef69f0ebc9c452"
+  },
+  "course_number": "4360",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "624136e30cef69f0ebc9c487"
+  },
+  "course_number": "6311",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624146680cef69f0ebc9c565"
+  },
+  "course_number": "4391",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146940cef69f0ebc9c575"
+  },
+  "course_number": "5348",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a10cef69f0ebc9c599"
+  },
+  "course_number": "6327",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a50cef69f0ebc9c5b3"
+  },
+  "course_number": "6361",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241df99e0a87a87f38b227e"
+  },
+  "course_number": "3325",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "62410a62217d3d0a63f72ee7"
+  },
+  "course_number": "3100",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410a6e217d3d0a63f72f33"
+  },
+  "course_number": "6312",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410ab7217d3d0a63f72f91"
+  },
+  "course_number": "6389",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410c43217d3d0a63f72fc0"
+  },
+  "course_number": "6302",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410c47217d3d0a63f72fc2"
+  },
+  "course_number": "6303",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "624118018f1108457d004b52"
+  },
+  "course_number": "3350",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "624118ce8f1108457d004ba5"
+  },
+  "course_number": "4310",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62411ad90cef69f0ebc9c031"
+  },
+  "course_number": "6306",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411ada0cef69f0ebc9c033"
+  },
+  "course_number": "6311",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62411adb0cef69f0ebc9c03d"
+  },
+  "course_number": "7228",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "624124fd0cef69f0ebc9c1b7"
+  },
+  "course_number": "6342",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624124fe0cef69f0ebc9c1c1"
+  },
+  "course_number": "6375",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624124ff0cef69f0ebc9c1ca"
+  },
+  "course_number": "6394",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624125000cef69f0ebc9c1d0"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624125d70cef69f0ebc9c1ef"
+  },
+  "course_number": "7301",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "62412c880cef69f0ebc9c2ed"
+  },
+  "course_number": "6392",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624131140cef69f0ebc9c38d"
+  },
+  "course_number": "4335",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241350a0cef69f0ebc9c3e0"
+  },
+  "course_number": "4375",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241356e0cef69f0ebc9c3e8"
+  },
+  "course_number": "5344",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135700cef69f0ebc9c3fe"
+  },
+  "course_number": "7207",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135710cef69f0ebc9c400"
+  },
+  "course_number": "7208",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136280cef69f0ebc9c454"
+  },
+  "course_number": "4370",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "624136d40cef69f0ebc9c485"
+  },
+  "course_number": "6307",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62410a63217d3d0a63f72ef0"
+  },
+  "course_number": "3101",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410ab8217d3d0a63f72f93"
+  },
+  "course_number": "7324",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b53217d3d0a63f72f9f"
+  },
+  "course_number": "6322",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b58217d3d0a63f72fa1"
+  },
+  "course_number": "6331",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b5a217d3d0a63f72fa3"
+  },
+  "course_number": "6332",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b95217d3d0a63f72fa5"
+  },
+  "course_number": "6333",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410d0e217d3d0a63f72fd4"
+  },
+  "course_number": "3320",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410d19217d3d0a63f72fd8"
+  },
+  "course_number": "4320",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410d24217d3d0a63f72fdc"
+  },
+  "course_number": "4920",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "624118228f1108457d004b63"
+  },
+  "course_number": "2342",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "624118cd8f1108457d004b9b"
+  },
+  "course_number": "3378",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624118cd8f1108457d004ba1"
+  },
+  "course_number": "3381",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "624121720cef69f0ebc9c12a"
+  },
+  "course_number": "4V40",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121740cef69f0ebc9c13d"
+  },
+  "course_number": "6331",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121770cef69f0ebc9c154"
+  },
+  "course_number": "6V02",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121770cef69f0ebc9c156"
+  },
+  "course_number": "6V50",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624124f80cef69f0ebc9c19d"
+  },
+  "course_number": "3350",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c850cef69f0ebc9c2de"
+  },
+  "course_number": "6363",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624131160cef69f0ebc9c398"
+  },
+  "course_number": "5361",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624131a40cef69f0ebc9c3aa"
+  },
+  "course_number": "2312",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "6241356f0cef69f0ebc9c3f0"
+  },
+  "course_number": "6240",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241356f0cef69f0ebc9c3f5"
+  },
+  "course_number": "6308",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136b40cef69f0ebc9c482"
+  },
+  "course_number": "4337",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624136f20cef69f0ebc9c48e"
+  },
+  "course_number": "7315",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624136f20cef69f0ebc9c491"
+  },
+  "course_number": "8V02",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624136f20cef69f0ebc9c494"
+  },
+  "course_number": "8V92",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624145170cef69f0ebc9c527"
+  },
+  "course_number": "3376",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a20cef69f0ebc9c59b"
+  },
+  "course_number": "6329",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146a20cef69f0ebc9c5a2"
+  },
+  "course_number": "6348",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241e03ae0a87a87f38b22a0"
+  },
+  "course_number": "3040",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "62410a79217d3d0a63f72f7a"
+  },
+  "course_number": "6367",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "62410b96217d3d0a63f72fab"
+  },
+  "course_number": "6348",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410b98217d3d0a63f72fad"
+  },
+  "course_number": "6372",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410bb7217d3d0a63f72fb0"
+  },
+  "course_number": "6373",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410bbe217d3d0a63f72fb5"
+  },
+  "course_number": "6V71",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410c4b217d3d0a63f72fc4"
+  },
+  "course_number": "6305",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62410ce0217d3d0a63f72fcd"
+  },
+  "course_number": "2040",
+  "subject_prefix": "AERO"
+},{
+  "_id": {
+    "$oid": "62410db0217d3d0a63f72fe6"
+  },
+  "course_number": "3320",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "62411adc0cef69f0ebc9c04c"
+  },
+  "course_number": "7V82",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241216f0cef69f0ebc9c118"
+  },
+  "course_number": "4371",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121770cef69f0ebc9c151"
+  },
+  "course_number": "6385",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624124fa0cef69f0ebc9c1a6"
+  },
+  "course_number": "4330",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624124fe0cef69f0ebc9c1be"
+  },
+  "course_number": "6372",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c870cef69f0ebc9c2e6"
+  },
+  "course_number": "6378",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412c880cef69f0ebc9c2ef"
+  },
+  "course_number": "7V80",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412d4c0cef69f0ebc9c304"
+  },
+  "course_number": "4313",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62412d5a0cef69f0ebc9c306"
+  },
+  "course_number": "4353",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62412d610cef69f0ebc9c30b"
+  },
+  "course_number": "4375",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624131150cef69f0ebc9c395"
+  },
+  "course_number": "5355",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241356e0cef69f0ebc9c3e6"
+  },
+  "course_number": "5341",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135700cef69f0ebc9c3f7"
+  },
+  "course_number": "6320",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135730cef69f0ebc9c413"
+  },
+  "course_number": "7392",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241369c0cef69f0ebc9c45e"
+  },
+  "course_number": "2306",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624136ee0cef69f0ebc9c48c"
+  },
+  "course_number": "6381",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624146a00cef69f0ebc9c593"
+  },
+  "course_number": "6322",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241e036e0a87a87f38b2299"
+  },
+  "course_number": "3020",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "6241e037e0a87a87f38b229d"
+  },
+  "course_number": "3030",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "62410b95217d3d0a63f72fa9"
+  },
+  "course_number": "6342",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62410db4217d3d0a63f72fe9"
+  },
+  "course_number": "3322",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "624118008f1108457d004b4a"
+  },
+  "course_number": "2300",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "624121720cef69f0ebc9c130"
+  },
+  "course_number": "5381",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624121730cef69f0ebc9c134"
+  },
+  "course_number": "5440",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "624122d60cef69f0ebc9c177"
+  },
+  "course_number": "4310",
+  "subject_prefix": "BLAW"
+},{
+  "_id": {
+    "$oid": "624124ff0cef69f0ebc9c1c8"
+  },
+  "course_number": "6389",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62412c840cef69f0ebc9c2dc"
+  },
+  "course_number": "6352",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62412c880cef69f0ebc9c2eb"
+  },
+  "course_number": "6390",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624131020cef69f0ebc9c347"
+  },
+  "course_number": "1316",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6241310f0cef69f0ebc9c377"
+  },
+  "course_number": "2328",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "624135080cef69f0ebc9c3cf"
+  },
+  "course_number": "3338",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6241356e0cef69f0ebc9c3eb"
+  },
+  "course_number": "6111",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135720cef69f0ebc9c409"
+  },
+  "course_number": "7304",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135720cef69f0ebc9c40e"
+  },
+  "course_number": "7336",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135720cef69f0ebc9c410"
+  },
+  "course_number": "7384",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624135730cef69f0ebc9c416"
+  },
+  "course_number": "7V56",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624136270cef69f0ebc9c44e"
+  },
+  "course_number": "4350",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "624146aa0cef69f0ebc9c5ca"
+  },
+  "course_number": "6376",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624148ce0cef69f0ebc9c61a"
+  },
+  "course_number": "3315",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624146ad0cef69f0ebc9c5e0"
+  },
+  "course_number": "6392",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624148fe0cef69f0ebc9c63f"
+  },
+  "course_number": "6V01",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624150160cef69f0ebc9c728"
+  },
+  "course_number": "6336",
+  "subject_prefix": "EECS"
+},{
+  "_id": {
+    "$oid": "6241509c0cef69f0ebc9c732"
+  },
+  "course_number": "7V88",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "6241549e0cef69f0ebc9c76e"
+  },
+  "course_number": "6353",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62415eca0cef69f0ebc9c896"
+  },
+  "course_number": "6356",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ecb0cef69f0ebc9c8a2"
+  },
+  "course_number": "6381",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415fe17901d4c256b814db"
+  },
+  "course_number": "4322",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241603c7901d4c256b81531"
+  },
+  "course_number": "7361",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624164f9e38ffbda9329314b"
+  },
+  "course_number": "6333",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fbe38ffbda93293156"
+  },
+  "course_number": "6372",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241651be38ffbda93293174"
+  },
+  "course_number": "6335",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624165a7e38ffbda9329319c"
+  },
+  "course_number": "3324",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6241660ce38ffbda932931c6"
+  },
+  "course_number": "3301",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "62416858e38ffbda93293238"
+  },
+  "course_number": "7305",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624169e5e38ffbda93293260"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "62416b33e38ffbda93293285"
+  },
+  "course_number": "6V93",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62416bbae38ffbda93293291"
+  },
+  "course_number": "4306",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62416bbde38ffbda93293293"
+  },
+  "course_number": "4377",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62416faee38ffbda93293305"
+  },
+  "course_number": "1312",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "62417455e38ffbda93293355"
+  },
+  "course_number": "5V03",
+  "subject_prefix": "MAIS"
+},{
+  "_id": {
+    "$oid": "62417aade38ffbda9329346d"
+  },
+  "course_number": "4355",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aade38ffbda9329346f"
+  },
+  "course_number": "4362",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aaee38ffbda93293471"
+  },
+  "course_number": "4399",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418010e38ffbda932934e2"
+  },
+  "course_number": "4330",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418011e38ffbda932934e9"
+  },
+  "course_number": "4380",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418016e38ffbda93293501"
+  },
+  "course_number": "6314",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418019e38ffbda93293515"
+  },
+  "course_number": "6368",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "624183a9e38ffbda93293587"
+  },
+  "course_number": "6339",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62418614e38ffbda93293621"
+  },
+  "course_number": "6339",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "62418fade38ffbda93293680"
+  },
+  "course_number": "4120",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62418faee38ffbda93293686"
+  },
+  "course_number": "4347",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62418faee38ffbda93293688"
+  },
+  "course_number": "4385",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241905be38ffbda932936d6"
+  },
+  "course_number": "4375",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "624146af0cef69f0ebc9c5eb"
+  },
+  "course_number": "8V02",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624148cf0cef69f0ebc9c621"
+  },
+  "course_number": "4301",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624150980cef69f0ebc9c72f"
+  },
+  "course_number": "6379",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "624153510cef69f0ebc9c754"
+  },
+  "course_number": "6356",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "624153550cef69f0ebc9c756"
+  },
+  "course_number": "6357",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "624154aa0cef69f0ebc9c774"
+  },
+  "course_number": "6395",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624156400cef69f0ebc9c79a"
+  },
+  "course_number": "6336",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "624157040cef69f0ebc9c7aa"
+  },
+  "course_number": "4320",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "62415ebf0cef69f0ebc9c850"
+  },
+  "course_number": "4330",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ec00cef69f0ebc9c853"
+  },
+  "course_number": "4332",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ec00cef69f0ebc9c855"
+  },
+  "course_number": "4333",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ec70cef69f0ebc9c881"
+  },
+  "course_number": "6316",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ec70cef69f0ebc9c887"
+  },
+  "course_number": "6323",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415fe67901d4c256b81502"
+  },
+  "course_number": "6392",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe87901d4c256b8150e"
+  },
+  "course_number": "8V90",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624164f6e38ffbda9329313c"
+  },
+  "course_number": "6310",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fae38ffbda93293152"
+  },
+  "course_number": "6348",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fde38ffbda93293161"
+  },
+  "course_number": "7343",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fee38ffbda9329316c"
+  },
+  "course_number": "8V50",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241660de38ffbda932931ce"
+  },
+  "course_number": "3315",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624166b2e38ffbda932931fa"
+  },
+  "course_number": "6327",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624168e9e38ffbda93293246"
+  },
+  "course_number": "7340",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62416cfae38ffbda9329329c"
+  },
+  "course_number": "3309",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "62417432e38ffbda93293336"
+  },
+  "course_number": "3319",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417aabe38ffbda9329345d"
+  },
+  "course_number": "3312",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aaee38ffbda93293475"
+  },
+  "course_number": "6302",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aafe38ffbda9329347f"
+  },
+  "course_number": "6321",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417ab0e38ffbda93293484"
+  },
+  "course_number": "6390",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418010e38ffbda932934e5"
+  },
+  "course_number": "4360",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418015e38ffbda932934ff"
+  },
+  "course_number": "6313",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418563e38ffbda932935f3"
+  },
+  "course_number": "4340",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "624186a4e38ffbda9329362f"
+  },
+  "course_number": "5410",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624186abe38ffbda93293633"
+  },
+  "course_number": "6310",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62418763e38ffbda93293645"
+  },
+  "course_number": "5321",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "62418faee38ffbda9329368a"
+  },
+  "course_number": "4386",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62419082e38ffbda932936e3"
+  },
+  "course_number": "6321",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "624148ce0cef69f0ebc9c618"
+  },
+  "course_number": "3312",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624148d00cef69f0ebc9c62c"
+  },
+  "course_number": "4360",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624148d10cef69f0ebc9c630"
+  },
+  "course_number": "5322",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414f510cef69f0ebc9c71a"
+  },
+  "course_number": "4371",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "624151d10cef69f0ebc9c744"
+  },
+  "course_number": "8V70",
+  "subject_prefix": "EEGR"
+},{
+  "_id": {
+    "$oid": "624153df0cef69f0ebc9c75c"
+  },
+  "course_number": "6351",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "6241563c0cef69f0ebc9c797"
+  },
+  "course_number": "4313",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "624158d40cef69f0ebc9c7e5"
+  },
+  "course_number": "7371",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624158d80cef69f0ebc9c7e7"
+  },
+  "course_number": "7V81",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62415eb40cef69f0ebc9c806"
+  },
+  "course_number": "3100",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ecb0cef69f0ebc9c89f"
+  },
+  "course_number": "6380",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ed70cef69f0ebc9c8aa"
+  },
+  "course_number": "1312",
+  "subject_prefix": "FREN"
+},{
+  "_id": {
+    "$oid": "62415ed70cef69f0ebc9c8ac"
+  },
+  "course_number": "2312",
+  "subject_prefix": "FREN"
+},{
+  "_id": {
+    "$oid": "62415fe27901d4c256b814e7"
+  },
+  "course_number": "5322",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe67901d4c256b814fe"
+  },
+  "course_number": "6384",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe67901d4c256b81500"
+  },
+  "course_number": "6385",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe77901d4c256b8150b"
+  },
+  "course_number": "8399",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624160397901d4c256b8151d"
+  },
+  "course_number": "5322",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6241603c7901d4c256b81533"
+  },
+  "course_number": "7365",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624164f8e38ffbda93293143"
+  },
+  "course_number": "6319",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164f9e38ffbda93293147"
+  },
+  "course_number": "6331",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fae38ffbda9329314f"
+  },
+  "course_number": "6341",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624165a8e38ffbda932931a2"
+  },
+  "course_number": "3376",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624165a9e38ffbda932931a7"
+  },
+  "course_number": "3390",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624165a9e38ffbda932931a9"
+  },
+  "course_number": "3396",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624165aae38ffbda932931b1"
+  },
+  "course_number": "4376",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62416806e38ffbda9329321b"
+  },
+  "course_number": "6312",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62416817e38ffbda93293226"
+  },
+  "course_number": "6352",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624168e5e38ffbda93293244"
+  },
+  "course_number": "7315",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62416abee38ffbda93293262"
+  },
+  "course_number": "3093",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62416b32e38ffbda93293280"
+  },
+  "course_number": "6360",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62417434e38ffbda93293348"
+  },
+  "course_number": "3380",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417aaee38ffbda93293473"
+  },
+  "course_number": "5302",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aaee38ffbda93293477"
+  },
+  "course_number": "6309",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418018e38ffbda93293511"
+  },
+  "course_number": "6353",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418019e38ffbda9329351a"
+  },
+  "course_number": "6373",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241807de38ffbda93293533"
+  },
+  "course_number": "6355",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "62418086e38ffbda93293538"
+  },
+  "course_number": "7313",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "624186a0e38ffbda9329362d"
+  },
+  "course_number": "5371",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241905ae38ffbda932936d0"
+  },
+  "course_number": "4367",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241905ce38ffbda932936dc"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "624148fe0cef69f0ebc9c639"
+  },
+  "course_number": "6309",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624148ff0cef69f0ebc9c645"
+  },
+  "course_number": "7311",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414db90cef69f0ebc9c68b"
+  },
+  "course_number": "3382",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "624151560cef69f0ebc9c742"
+  },
+  "course_number": "7V81",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "624152520cef69f0ebc9c748"
+  },
+  "course_number": "6324",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624152d20cef69f0ebc9c74f"
+  },
+  "course_number": "6311",
+  "subject_prefix": "EEOP"
+},{
+  "_id": {
+    "$oid": "624152d60cef69f0ebc9c752"
+  },
+  "course_number": "7340",
+  "subject_prefix": "EEOP"
+},{
+  "_id": {
+    "$oid": "624154a70cef69f0ebc9c772"
+  },
+  "course_number": "6361",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624157560cef69f0ebc9c7c2"
+  },
+  "course_number": "6382",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "6241575d0cef69f0ebc9c7cd"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "62415ebf0cef69f0ebc9c84b"
+  },
+  "course_number": "4313",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ec90cef69f0ebc9c893"
+  },
+  "course_number": "6352",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415fdf7901d4c256b814d0"
+  },
+  "course_number": "2332",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe07901d4c256b814d4"
+  },
+  "course_number": "3434",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415ff27901d4c256b81510"
+  },
+  "course_number": "1312",
+  "subject_prefix": "GERM"
+},{
+  "_id": {
+    "$oid": "6241603a7901d4c256b81525"
+  },
+  "course_number": "6384",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6241603b7901d4c256b81529"
+  },
+  "course_number": "6388",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624164f7e38ffbda9329313e"
+  },
+  "course_number": "6313",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164f9e38ffbda93293149"
+  },
+  "course_number": "6332",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241651be38ffbda93293172"
+  },
+  "course_number": "6320",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624166b3e38ffbda93293200"
+  },
+  "course_number": "6340",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "62416bc1e38ffbda93293295"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62416d03e38ffbda932932a1"
+  },
+  "course_number": "3335",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "62416f31e38ffbda932932fa"
+  },
+  "course_number": "4354",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62416f32e38ffbda93293301"
+  },
+  "course_number": "4380",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417aace38ffbda93293468"
+  },
+  "course_number": "4302",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aafe38ffbda9329347d"
+  },
+  "course_number": "6320",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417ab0e38ffbda93293481"
+  },
+  "course_number": "6327",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418018e38ffbda93293513"
+  },
+  "course_number": "6367",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241801ae38ffbda9329351e"
+  },
+  "course_number": "6V49",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "624183b0e38ffbda932935b1"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62418611e38ffbda93293615"
+  },
+  "course_number": "6332",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6241869ae38ffbda93293629"
+  },
+  "course_number": "5355",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6241869be38ffbda9329362b"
+  },
+  "course_number": "5360",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624186afe38ffbda93293635"
+  },
+  "course_number": "6321",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62418face38ffbda93293678"
+  },
+  "course_number": "3328",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62418fade38ffbda93293682"
+  },
+  "course_number": "4316",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62418fafe38ffbda9329368c"
+  },
+  "course_number": "4V13",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "624146ab0cef69f0ebc9c5cf"
+  },
+  "course_number": "6380",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146ab0cef69f0ebc9c5d5"
+  },
+  "course_number": "6384",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146ae0cef69f0ebc9c5e4"
+  },
+  "course_number": "6V81",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624148d20cef69f0ebc9c632"
+  },
+  "course_number": "5397",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414f4f0cef69f0ebc9c711"
+  },
+  "course_number": "4367",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "6241500e0cef69f0ebc9c722"
+  },
+  "course_number": "6302",
+  "subject_prefix": "EECS"
+},{
+  "_id": {
+    "$oid": "624157560cef69f0ebc9c7c5"
+  },
+  "course_number": "6390",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624158af0cef69f0ebc9c7e1"
+  },
+  "course_number": "7304",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62415ec80cef69f0ebc9c88e"
+  },
+  "course_number": "6336",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415fe17901d4c256b814dd"
+  },
+  "course_number": "4325",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe17901d4c256b814df"
+  },
+  "course_number": "4390",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe27901d4c256b814e1"
+  },
+  "course_number": "4V08",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe47901d4c256b814f0"
+  },
+  "course_number": "5375",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241603b7901d4c256b8152d"
+  },
+  "course_number": "7310",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624164f8e38ffbda93293145"
+  },
+  "course_number": "6322",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fde38ffbda93293163"
+  },
+  "course_number": "7355",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624164fee38ffbda9329316a"
+  },
+  "course_number": "7V71",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241651be38ffbda93293170"
+  },
+  "course_number": "6316",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "62416845e38ffbda9329322f"
+  },
+  "course_number": "6390",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62416da9e38ffbda932932b7"
+  },
+  "course_number": "3373",
+  "subject_prefix": "ISNS"
+},{
+  "_id": {
+    "$oid": "62416e7de38ffbda932932ba"
+  },
+  "course_number": "3100",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62416fb5e38ffbda93293309"
+  },
+  "course_number": "2312",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "6241706ee38ffbda9329330b"
+  },
+  "course_number": "2V42",
+  "subject_prefix": "LANG"
+},{
+  "_id": {
+    "$oid": "62417433e38ffbda9329333d"
+  },
+  "course_number": "3328",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417aaae38ffbda93293455"
+  },
+  "course_number": "3307",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418011e38ffbda932934e7"
+  },
+  "course_number": "4370",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418012e38ffbda932934ef"
+  },
+  "course_number": "4382",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418016e38ffbda93293503"
+  },
+  "course_number": "6316",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418019e38ffbda93293518"
+  },
+  "course_number": "6371",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241801ae38ffbda93293520"
+  },
+  "course_number": "6V89",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418082e38ffbda93293535"
+  },
+  "course_number": "7311",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "62418612e38ffbda93293617"
+  },
+  "course_number": "6334",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "62418face38ffbda93293676"
+  },
+  "course_number": "3325",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62418fade38ffbda9329367e"
+  },
+  "course_number": "4118",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62419055e38ffbda932936ae"
+  },
+  "course_number": "3345",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241905ae38ffbda932936d2"
+  },
+  "course_number": "4371",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "624146ab0cef69f0ebc9c5d1"
+  },
+  "course_number": "6381",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624146ac0cef69f0ebc9c5da"
+  },
+  "course_number": "6387",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241473e0cef69f0ebc9c5f5"
+  },
+  "course_number": "2333",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624148ff0cef69f0ebc9c641"
+  },
+  "course_number": "7301",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414f450cef69f0ebc9c708"
+  },
+  "course_number": "4325",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "624151280cef69f0ebc9c73b"
+  },
+  "course_number": "6303",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "624152570cef69f0ebc9c74d"
+  },
+  "course_number": "6382",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624153dd0cef69f0ebc9c75a"
+  },
+  "course_number": "6330",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "624156ef0cef69f0ebc9c7a8"
+  },
+  "course_number": "4311",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624157550cef69f0ebc9c7c0"
+  },
+  "course_number": "6378",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "62415fe07901d4c256b814d7"
+  },
+  "course_number": "3470",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe27901d4c256b814e5"
+  },
+  "course_number": "5306",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe47901d4c256b814f2"
+  },
+  "course_number": "5387",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624160387901d4c256b81515"
+  },
+  "course_number": "4325",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6241603b7901d4c256b81527"
+  },
+  "course_number": "6385",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624164fce38ffbda9329315f"
+  },
+  "course_number": "7338",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6241651ce38ffbda93293178"
+  },
+  "course_number": "6390",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624165a7e38ffbda93293199"
+  },
+  "course_number": "3313",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624165abe38ffbda932931b3"
+  },
+  "course_number": "6310",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62416813e38ffbda93293224"
+  },
+  "course_number": "6351",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62416823e38ffbda9329322d"
+  },
+  "course_number": "6373",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62416857e38ffbda93293234"
+  },
+  "course_number": "6393",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62416b2ce38ffbda93293279"
+  },
+  "course_number": "4330",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62416bb6e38ffbda9329328e"
+  },
+  "course_number": "4304",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62416c7ae38ffbda93293297"
+  },
+  "course_number": "2130",
+  "subject_prefix": "ISAH"
+},{
+  "_id": {
+    "$oid": "62416cffe38ffbda9329329f"
+  },
+  "course_number": "3312",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "62416e7ee38ffbda932932bd"
+  },
+  "course_number": "3211",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62416f30e38ffbda932932f1"
+  },
+  "course_number": "4343",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417aafe38ffbda9329347b"
+  },
+  "course_number": "6318",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241800ce38ffbda932934d3"
+  },
+  "course_number": "3V95",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418016e38ffbda93293505"
+  },
+  "course_number": "6317",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418017e38ffbda93293507"
+  },
+  "course_number": "6333",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62418018e38ffbda9329350d"
+  },
+  "course_number": "6338",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241804de38ffbda9329352e"
+  },
+  "course_number": "6350",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "624183aee38ffbda932935a5"
+  },
+  "course_number": "6372",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62418614e38ffbda93293623"
+  },
+  "course_number": "6382",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "624186cfe38ffbda93293637"
+  },
+  "course_number": "6324",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624186e6e38ffbda93293641"
+  },
+  "course_number": "6382",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62418face38ffbda9329367a"
+  },
+  "course_number": "3382",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62418feee38ffbda93293698"
+  },
+  "course_number": "2333",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "62419056e38ffbda932936b6"
+  },
+  "course_number": "4351",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "62419059e38ffbda932936c3"
+  },
+  "course_number": "4357",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "62419107e38ffbda93293700"
+  },
+  "course_number": "4350",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "624147450cef69f0ebc9c5f9"
+  },
+  "course_number": "2336",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624147490cef69f0ebc9c5fb"
+  },
+  "course_number": "3333",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "6241476d0cef69f0ebc9c5ff"
+  },
+  "course_number": "3347",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624148d00cef69f0ebc9c62e"
+  },
+  "course_number": "4382",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624148fe0cef69f0ebc9c63b"
+  },
+  "course_number": "6336",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414db90cef69f0ebc9c688"
+  },
+  "course_number": "3370",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "6241524f0cef69f0ebc9c746"
+  },
+  "course_number": "6321",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624157510cef69f0ebc9c7b6"
+  },
+  "course_number": "6316",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "6241595c0cef69f0ebc9c7ed"
+  },
+  "course_number": "3321",
+  "subject_prefix": "FILM"
+},{
+  "_id": {
+    "$oid": "62415ebf0cef69f0ebc9c84d"
+  },
+  "course_number": "4321",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415ec80cef69f0ebc9c88c"
+  },
+  "course_number": "6335",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415f247901d4c256b814b7"
+  },
+  "course_number": "3331",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "62415ff27901d4c256b81513"
+  },
+  "course_number": "2312",
+  "subject_prefix": "GERM"
+},{
+  "_id": {
+    "$oid": "624164fae38ffbda93293154"
+  },
+  "course_number": "6359",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624165a8e38ffbda932931a0"
+  },
+  "course_number": "3374",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62416609e38ffbda932931b7"
+  },
+  "course_number": "1100",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "62416808e38ffbda9329321d"
+  },
+  "course_number": "6313",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62417431e38ffbda9329332d"
+  },
+  "course_number": "3310",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417433e38ffbda93293341"
+  },
+  "course_number": "3332",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417434e38ffbda9329334a"
+  },
+  "course_number": "4329",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417455e38ffbda93293353"
+  },
+  "course_number": "5335",
+  "subject_prefix": "MAIS"
+},{
+  "_id": {
+    "$oid": "62417aabe38ffbda93293460"
+  },
+  "course_number": "3321",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62417aace38ffbda93293464"
+  },
+  "course_number": "3380",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418018e38ffbda9329350f"
+  },
+  "course_number": "6347",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241837be38ffbda9329355b"
+  },
+  "course_number": "6311",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62418611e38ffbda93293611"
+  },
+  "course_number": "6329",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "624186a7e38ffbda93293631"
+  },
+  "course_number": "5440",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624186e6e38ffbda9329363d"
+  },
+  "course_number": "6341",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624186e6e38ffbda9329363f"
+  },
+  "course_number": "6355",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624186e7e38ffbda93293643"
+  },
+  "course_number": "7V80",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624146ad0cef69f0ebc9c5dc"
+  },
+  "course_number": "6388",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624148d00cef69f0ebc9c626"
+  },
+  "course_number": "4336",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624148ff0cef69f0ebc9c643"
+  },
+  "course_number": "7302",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414f4f0cef69f0ebc9c70e"
+  },
+  "course_number": "4360",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62414f500cef69f0ebc9c716"
+  },
+  "course_number": "4370",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "624152550cef69f0ebc9c74a"
+  },
+  "course_number": "6327",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624153e80cef69f0ebc9c760"
+  },
+  "course_number": "6394",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "6241549a0cef69f0ebc9c76c"
+  },
+  "course_number": "6352",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624158b40cef69f0ebc9c7e3"
+  },
+  "course_number": "7316",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62415ecc0cef69f0ebc9c8a8"
+  },
+  "course_number": "7335",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62415f257901d4c256b814bb"
+  },
+  "course_number": "3372",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "62415fe27901d4c256b814e3"
+  },
+  "course_number": "5101",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe37901d4c256b814ec"
+  },
+  "course_number": "5326",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62415fe37901d4c256b814ee"
+  },
+  "course_number": "5335",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624160387901d4c256b81517"
+  },
+  "course_number": "4382",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624160397901d4c256b8151b"
+  },
+  "course_number": "4386",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6241603c7901d4c256b8152f"
+  },
+  "course_number": "7360",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624165a8e38ffbda932931a4"
+  },
+  "course_number": "3386",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62416811e38ffbda93293222"
+  },
+  "course_number": "6343",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62416bb3e38ffbda9329328c"
+  },
+  "course_number": "4303",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62416f31e38ffbda932932f8"
+  },
+  "course_number": "4352",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62417433e38ffbda9329333b"
+  },
+  "course_number": "3326",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62417aafe38ffbda93293479"
+  },
+  "course_number": "6311",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62418019e38ffbda9329351c"
+  },
+  "course_number": "6393",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6241850fe38ffbda932935b9"
+  },
+  "course_number": "3100",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "624186dee38ffbda93293639"
+  },
+  "course_number": "6327",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62419059e38ffbda932936c6"
+  },
+  "course_number": "4358",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6241905be38ffbda932936d4"
+  },
+  "course_number": "4372",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "62419083e38ffbda932936e8"
+  },
+  "course_number": "7302",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "62419083e38ffbda932936ea"
+  },
+  "course_number": "7313",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "62419103e38ffbda932936fe"
+  },
+  "course_number": "4331",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241941ce38ffbda9329373c"
+  },
+  "course_number": "4340",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "62419427e38ffbda93293777"
+  },
+  "course_number": "6378",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241942de38ffbda9329379b"
+  },
+  "course_number": "7351",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "62419422e38ffbda9329375d"
+  },
+  "course_number": "6355",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "62419427e38ffbda9329377b"
+  },
+  "course_number": "6389",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "62419676e38ffbda932937f6"
+  },
+  "course_number": "1122",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419695e38ffbda932937f8"
+  },
+  "course_number": "1129",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419c2ae38ffbda9329385c"
+  },
+  "course_number": "2421",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2939f98f082445203b7"
+  },
+  "course_number": "6374",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f37c9f98f0824452040e"
+  },
+  "course_number": "4373",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241fa239f98f082445204e8"
+  },
+  "course_number": "5304",
+  "subject_prefix": "SMED"
+},{
+  "_id": {
+    "$oid": "6241fda59f98f0824452051b"
+  },
+  "course_number": "3325",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fe0a9f98f0824452054d"
+  },
+  "course_number": "3340",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241fe0e9f98f08244520568"
+  },
+  "course_number": "4393",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "624202de9f98f0824452062a"
+  },
+  "course_number": "3350",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e49f98f0824452063f"
+  },
+  "course_number": "4367",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e49f98f08244520641"
+  },
+  "course_number": "4388",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "6241f515c9e4c7fafbcbf283"
+  },
+  "course_number": "6194",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "6241fde6c9e4c7fafbcbf411"
+  },
+  "course_number": "7V68",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241942ce38ffbda93293795"
+  },
+  "course_number": "7309",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624194d0e38ffbda932937b0"
+  },
+  "course_number": "4340",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419536e38ffbda932937c7"
+  },
+  "course_number": "6374",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419540e38ffbda932937d2"
+  },
+  "course_number": "7350",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "624195cde38ffbda932937dd"
+  },
+  "course_number": "2317",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "624195d1e38ffbda932937df"
+  },
+  "course_number": "4305",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62419c31e38ffbda9329388d"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2289f98f0824452036f"
+  },
+  "course_number": "6356",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f2909f98f082445203a0"
+  },
+  "course_number": "4378",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f2929f98f082445203af"
+  },
+  "course_number": "6301",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f37d9f98f08244520414"
+  },
+  "course_number": "4393",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f3d59f98f08244520425"
+  },
+  "course_number": "6332",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241fa259f98f082445204ea"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "SMED"
+},{
+  "_id": {
+    "$oid": "6241fda49f98f08244520514"
+  },
+  "course_number": "2320",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fda69f98f08244520521"
+  },
+  "course_number": "3379",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fda79f98f08244520527"
+  },
+  "course_number": "4357",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fda89f98f0824452052f"
+  },
+  "course_number": "6356",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fe0c9f98f08244520557"
+  },
+  "course_number": "3345",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241fe6d9f98f0824452058a"
+  },
+  "course_number": "6326",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241ff8b9f98f082445205c8"
+  },
+  "course_number": "6321",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "624202d39f98f082445205fb"
+  },
+  "course_number": "2336",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202d89f98f08244520610"
+  },
+  "course_number": "3150",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e59f98f08244520647"
+  },
+  "course_number": "4390",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624203ae9f98f08244520655"
+  },
+  "course_number": "2020",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "6241f57ec9e4c7fafbcbf2e7"
+  },
+  "course_number": "6314",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "624194f5e38ffbda932937b5"
+  },
+  "course_number": "4352",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241952fe38ffbda932937c1"
+  },
+  "course_number": "6326",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419541e38ffbda932937d4"
+  },
+  "course_number": "7360",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419661e38ffbda932937e8"
+  },
+  "course_number": "1103",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419c2be38ffbda93293861"
+  },
+  "course_number": "3327",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2ee38ffbda93293875"
+  },
+  "course_number": "4V10",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2289f98f08244520373"
+  },
+  "course_number": "6366",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f28e9f98f0824452038b"
+  },
+  "course_number": "4301",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f28f9f98f0824452038d"
+  },
+  "course_number": "4314",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f28f9f98f08244520391"
+  },
+  "course_number": "4356",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f2929f98f082445203ac"
+  },
+  "course_number": "6300",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f3749f98f082445203da"
+  },
+  "course_number": "3351",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f37c9f98f0824452040b"
+  },
+  "course_number": "4372",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f3ce9f98f08244520421"
+  },
+  "course_number": "6320",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241f46e9f98f08244520433"
+  },
+  "course_number": "4321",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241f7449f98f08244520485"
+  },
+  "course_number": "5332",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241f9609f98f082445204c1"
+  },
+  "course_number": "4381",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241fda49f98f08244520512"
+  },
+  "course_number": "2305",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fda69f98f08244520525"
+  },
+  "course_number": "4306",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fe6c9f98f08244520580"
+  },
+  "course_number": "4352",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241ff4f9f98f0824452059b"
+  },
+  "course_number": "6302",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "624202cc9f98f082445205f1"
+  },
+  "course_number": "2305",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202d69f98f08244520608"
+  },
+  "course_number": "3102",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e29f98f08244520637"
+  },
+  "course_number": "4341",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e39f98f0824452063b"
+  },
+  "course_number": "4348",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e49f98f0824452063d"
+  },
+  "course_number": "4360",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e59f98f08244520643"
+  },
+  "course_number": "4389",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "6241f516c9e4c7fafbcbf289"
+  },
+  "course_number": "6292",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "6241f580c9e4c7fafbcbf2f2"
+  },
+  "course_number": "7325",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62419111e38ffbda93293706"
+  },
+  "course_number": "4360",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241942ce38ffbda93293797"
+  },
+  "course_number": "7311",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241942de38ffbda93293799"
+  },
+  "course_number": "7320",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624194cfe38ffbda932937a8"
+  },
+  "course_number": "3379",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "624194fce38ffbda932937bb"
+  },
+  "course_number": "6315",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419531e38ffbda932937c3"
+  },
+  "course_number": "6342",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419540e38ffbda932937d0"
+  },
+  "course_number": "7314",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419658e38ffbda932937e2"
+  },
+  "course_number": "1100",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419c2de38ffbda9329386f"
+  },
+  "course_number": "4371",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2ee38ffbda93293873"
+  },
+  "course_number": "4392",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2299f98f08244520375"
+  },
+  "course_number": "6368",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f28e9f98f08244520385"
+  },
+  "course_number": "3326",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f28e9f98f08244520389"
+  },
+  "course_number": "3362",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f28f9f98f08244520393"
+  },
+  "course_number": "4360",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f2929f98f082445203b1"
+  },
+  "course_number": "6331",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f2939f98f082445203b9"
+  },
+  "course_number": "7318",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f3a69f98f0824452041c"
+  },
+  "course_number": "6313",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241f9a19f98f082445204d8"
+  },
+  "course_number": "6361",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241fda59f98f0824452051d"
+  },
+  "course_number": "3333",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fe0d9f98f08244520564"
+  },
+  "course_number": "4367",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "624201969f98f082445205e6"
+  },
+  "course_number": "1337",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202da9f98f08244520618"
+  },
+  "course_number": "3302",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "6241f702c9e4c7fafbcbf341"
+  },
+  "course_number": "3V82",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241f92ac9e4c7fafbcbf371"
+  },
+  "course_number": "7303",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "6241fb25c9e4c7fafbcbf3c8"
+  },
+  "course_number": "7325",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6241fdd9c9e4c7fafbcbf407"
+  },
+  "course_number": "6V09",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241fde0c9e4c7fafbcbf40b"
+  },
+  "course_number": "7323",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241941de38ffbda9329373e"
+  },
+  "course_number": "4360",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241965ce38ffbda932937e5"
+  },
+  "course_number": "1102",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419663e38ffbda932937eb"
+  },
+  "course_number": "1106",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419c2ce38ffbda93293868"
+  },
+  "course_number": "4302",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2de38ffbda9329386a"
+  },
+  "course_number": "4311",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2ee38ffbda93293877"
+  },
+  "course_number": "5302",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2fe38ffbda9329387b"
+  },
+  "course_number": "5313",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2fe38ffbda9329387d"
+  },
+  "course_number": "5320",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c31e38ffbda9329388b"
+  },
+  "course_number": "8V80",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f1fe9f98f08244520367"
+  },
+  "course_number": "4301",
+  "subject_prefix": "PPOL"
+},{
+  "_id": {
+    "$oid": "6241f37e9f98f0824452041a"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f6c59f98f08244520481"
+  },
+  "course_number": "4333",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "6241f9a09f98f082445204d3"
+  },
+  "course_number": "6360",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241fe0d9f98f08244520562"
+  },
+  "course_number": "4342",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241fe6d9f98f0824452058c"
+  },
+  "course_number": "6338",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241fe6e9f98f08244520592"
+  },
+  "course_number": "7338",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241fe779f98f08244520596"
+  },
+  "course_number": "6324",
+  "subject_prefix": "SYSE"
+},{
+  "_id": {
+    "$oid": "6241ff519f98f082445205a7"
+  },
+  "course_number": "6306",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241ff8c9f98f082445205ca"
+  },
+  "course_number": "6325",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "624202d49f98f08244520601"
+  },
+  "course_number": "3101",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202d99f98f08244520615"
+  },
+  "course_number": "3301",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202db9f98f0824452061c"
+  },
+  "course_number": "3340",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e69f98f0824452064b"
+  },
+  "course_number": "6378",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202e79f98f0824452064e"
+  },
+  "course_number": "6385",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "6241f534c9e4c7fafbcbf2cc"
+  },
+  "course_number": "4342",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "6241f57ec9e4c7fafbcbf2ec"
+  },
+  "course_number": "6352",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241f702c9e4c7fafbcbf33e"
+  },
+  "course_number": "3V81",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241fdd0c9e4c7fafbcbf400"
+  },
+  "course_number": "5340",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241fdddc9e4c7fafbcbf409"
+  },
+  "course_number": "7303",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241fde3c9e4c7fafbcbf40e"
+  },
+  "course_number": "7345",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241941ce38ffbda9329373a"
+  },
+  "course_number": "4320",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624194d2e38ffbda932937b3"
+  },
+  "course_number": "4345",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419699e38ffbda932937fa"
+  },
+  "course_number": "1130",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62419c2de38ffbda9329386c"
+  },
+  "course_number": "4328",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2299f98f08244520379"
+  },
+  "course_number": "6374",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f28d9f98f0824452037f"
+  },
+  "course_number": "3301",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f2909f98f08244520395"
+  },
+  "course_number": "4364",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f2929f98f082445203b5"
+  },
+  "course_number": "6365",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f3d19f98f08244520423"
+  },
+  "course_number": "6331",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241f96d9f98f082445204c8"
+  },
+  "course_number": "5V81",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241f99f9f98f082445204d1"
+  },
+  "course_number": "6359",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241fda79f98f08244520529"
+  },
+  "course_number": "4384",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fda79f98f0824452052d"
+  },
+  "course_number": "6315",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241f580c9e4c7fafbcbf2f4"
+  },
+  "course_number": "7326",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241f703c9e4c7fafbcbf345"
+  },
+  "course_number": "4366",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241f705c9e4c7fafbcbf34e"
+  },
+  "course_number": "6345",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62419532e38ffbda932937c5"
+  },
+  "course_number": "6344",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419110e38ffbda93293704"
+  },
+  "course_number": "4354",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "62419540e38ffbda932937cb"
+  },
+  "course_number": "6386",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419c2be38ffbda9329385f"
+  },
+  "course_number": "3312",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2ee38ffbda93293879"
+  },
+  "course_number": "5305",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c2fe38ffbda9329387f"
+  },
+  "course_number": "5332",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2289f98f0824452036d"
+  },
+  "course_number": "6347",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f28e9f98f08244520387"
+  },
+  "course_number": "3333",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f28f9f98f0824452038f"
+  },
+  "course_number": "4330",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f6c19f98f0824452047f"
+  },
+  "course_number": "4332",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "6241f7499f98f08244520487"
+  },
+  "course_number": "5338",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6241f96c9f98f082445204c6"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241fda69f98f0824452051f"
+  },
+  "course_number": "3352",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fda89f98f08244520533"
+  },
+  "course_number": "6386",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fe0a9f98f0824452054b"
+  },
+  "course_number": "3305",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241fe0d9f98f08244520566"
+  },
+  "course_number": "4375",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241fe6c9f98f08244520582"
+  },
+  "course_number": "4382",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241fe6c9f98f08244520584"
+  },
+  "course_number": "5352",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241fe6e9f98f0824452058e"
+  },
+  "course_number": "6339",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241ff529f98f082445205ac"
+  },
+  "course_number": "6309",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "624201959f98f082445205e1"
+  },
+  "course_number": "1202",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "6241f704c9e4c7fafbcbf34c"
+  },
+  "course_number": "6341",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62419504e38ffbda932937bf"
+  },
+  "course_number": "6324",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62419c2fe38ffbda93293881"
+  },
+  "course_number": "5371",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c30e38ffbda93293885"
+  },
+  "course_number": "5381",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62419c30e38ffbda93293889"
+  },
+  "course_number": "6301",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241f2279f98f08244520369"
+  },
+  "course_number": "6321",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f2279f98f0824452036b"
+  },
+  "course_number": "6342",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f2289f98f08244520371"
+  },
+  "course_number": "6365",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f2299f98f08244520377"
+  },
+  "course_number": "6372",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f2299f98f0824452037b"
+  },
+  "course_number": "7319",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241f2929f98f082445203b3"
+  },
+  "course_number": "6347",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241f3739f98f082445203d4"
+  },
+  "course_number": "3338",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f3799f98f082445203f6"
+  },
+  "course_number": "4325",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f37c9f98f08244520410"
+  },
+  "course_number": "4375",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6241f3d99f98f08244520427"
+  },
+  "course_number": "6333",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241f4789f98f08244520439"
+  },
+  "course_number": "6323",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "6241f6429f98f0824452047b"
+  },
+  "course_number": "4302",
+  "subject_prefix": "RHET"
+},{
+  "_id": {
+    "$oid": "6241f8e29f98f082445204ab"
+  },
+  "course_number": "3376",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241fa209f98f082445204e5"
+  },
+  "course_number": "5302",
+  "subject_prefix": "SMED"
+},{
+  "_id": {
+    "$oid": "6241fda49f98f08244520510"
+  },
+  "course_number": "2303",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241fe0a9f98f08244520549"
+  },
+  "course_number": "3304",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6241fe779f98f08244520594"
+  },
+  "course_number": "6322",
+  "subject_prefix": "SYSE"
+},{
+  "_id": {
+    "$oid": "624202dd9f98f08244520623"
+  },
+  "course_number": "3345",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624202df9f98f0824452062d"
+  },
+  "course_number": "4141",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624203a99f98f08244520653"
+  },
+  "course_number": "2014",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "624203b09f98f08244520657"
+  },
+  "course_number": "2V96",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "6241f57ec9e4c7fafbcbf2ea"
+  },
+  "course_number": "6316",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241f703c9e4c7fafbcbf343"
+  },
+  "course_number": "4353",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241fb25c9e4c7fafbcbf3c5"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6241fef2c9e4c7fafbcbf422"
+  },
+  "course_number": "3320",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241ff03c9e4c7fafbcbf42c"
+  },
+  "course_number": "6332",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62421118c9e4c7fafbcbf524"
+  },
+  "course_number": "8V21",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241fef7c9e4c7fafbcbf426"
+  },
+  "course_number": "4336",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62420a03c9e4c7fafbcbf49d"
+  },
+  "course_number": "6372",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "6242139cc9e4c7fafbcbf53c"
+  },
+  "course_number": "6310",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6242142dc9e4c7fafbcbf54c"
+  },
+  "course_number": "3392",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624217b7c9e4c7fafbcbf572"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624221d4c9e4c7fafbcbf64a"
+  },
+  "course_number": "5301",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "62422555c9e4c7fafbcbf6a8"
+  },
+  "course_number": "6369",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62422611c9e4c7fafbcbf6ad"
+  },
+  "course_number": "2120",
+  "subject_prefix": "PHIN"
+},{
+  "_id": {
+    "$oid": "62422955c9e4c7fafbcbf6ea"
+  },
+  "course_number": "6335",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "62422b93c9e4c7fafbcbf6fd"
+  },
+  "course_number": "5337",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6240bf35ba30b4ebd5adb72e"
+  },
+  "course_number": "7314",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "6240e220ba30b4ebd5adb8dd"
+  },
+  "course_number": "7342",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240e221ba30b4ebd5adb8df"
+  },
+  "course_number": "8188",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240ee1bba30b4ebd5adb9b9"
+  },
+  "course_number": "4315",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "6240ee2bba30b4ebd5adb9c4"
+  },
+  "course_number": "4V75",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62410693ba30b4ebd5adbc08"
+  },
+  "course_number": "4315",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62411195ba30b4ebd5adbe32"
+  },
+  "course_number": "7327",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "62411335ba30b4ebd5adbe50"
+  },
+  "course_number": "7V82",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "6241158bba30b4ebd5adbe79"
+  },
+  "course_number": "6367",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62411896ba30b4ebd5adbed1"
+  },
+  "course_number": "6398",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "62411b84ba30b4ebd5adbf03"
+  },
+  "course_number": "3342",
+  "subject_prefix": "FILM"
+},{
+  "_id": {
+    "$oid": "62412032ba30b4ebd5adbfbe"
+  },
+  "course_number": "3124",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62412037ba30b4ebd5adbfdd"
+  },
+  "course_number": "5336",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62412a69ba30b4ebd5adc13a"
+  },
+  "course_number": "6350",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62412afbba30b4ebd5adc168"
+  },
+  "course_number": "6331",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "62412cd9ba30b4ebd5adc19a"
+  },
+  "course_number": "4375",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62413252ba30b4ebd5adc21b"
+  },
+  "course_number": "3309",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "624132cbba30b4ebd5adc238"
+  },
+  "course_number": "3382",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62413faeba30b4ebd5adc377"
+  },
+  "course_number": "6305",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62413fafba30b4ebd5adc37d"
+  },
+  "course_number": "6316",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62413fb0ba30b4ebd5adc383"
+  },
+  "course_number": "6340",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62413fb1ba30b4ebd5adc388"
+  },
+  "course_number": "7319",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6241489cba30b4ebd5adc3aa"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "62414eb5ba30b4ebd5adc4a0"
+  },
+  "course_number": "5333",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "624154d3ba30b4ebd5adc588"
+  },
+  "course_number": "4361",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "624158bcba30b4ebd5adc631"
+  },
+  "course_number": "4386",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "624211d3c9e4c7fafbcbf527"
+  },
+  "course_number": "6331",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62421bf6c9e4c7fafbcbf5a8"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "LANG"
+},{
+  "_id": {
+    "$oid": "62422cf0c9e4c7fafbcbf725"
+  },
+  "course_number": "5301",
+  "subject_prefix": "SMED"
+},{
+  "_id": {
+    "$oid": "62422d6fc9e4c7fafbcbf72a"
+  },
+  "course_number": "3363",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6240c3f4ba30b4ebd5adb7a5"
+  },
+  "course_number": "2343",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "6242074ac9e4c7fafbcbf48a"
+  },
+  "course_number": "4168",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "6240e220ba30b4ebd5adb8d9"
+  },
+  "course_number": "7189",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240f55dba30b4ebd5adba5b"
+  },
+  "course_number": "5333",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62421105c9e4c7fafbcbf516"
+  },
+  "course_number": "3300",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6240f611ba30b4ebd5adba6a"
+  },
+  "course_number": "1302",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "6242110ec9e4c7fafbcbf51d"
+  },
+  "course_number": "4V80",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6240f7a8ba30b4ebd5adbaab"
+  },
+  "course_number": "6330",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624213a6c9e4c7fafbcbf543"
+  },
+  "course_number": "6385",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6240fa7aba30b4ebd5adbb1f"
+  },
+  "course_number": "3327",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62421670c9e4c7fafbcbf564"
+  },
+  "course_number": "6310",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6240faeaba30b4ebd5adbb38"
+  },
+  "course_number": "7342",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624217b4c9e4c7fafbcbf56f"
+  },
+  "course_number": "3V93",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241090eba30b4ebd5adbd00"
+  },
+  "course_number": "3369",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62422957c9e4c7fafbcbf6ec"
+  },
+  "course_number": "7V50",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "62411b6bba30b4ebd5adbef2"
+  },
+  "course_number": "6356",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6240fae7ba30b4ebd5adbb31"
+  },
+  "course_number": "6310",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62412084ba30b4ebd5adc003"
+  },
+  "course_number": "8V80",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241077bba30b4ebd5adbcdc"
+  },
+  "course_number": "3345",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62412195ba30b4ebd5adc015"
+  },
+  "course_number": "5311",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62410918ba30b4ebd5adbd2a"
+  },
+  "course_number": "7363",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241231bba30b4ebd5adc040"
+  },
+  "course_number": "4325",
+  "subject_prefix": "GST"
+},{
+  "_id": {
+    "$oid": "62411823ba30b4ebd5adbeb5"
+  },
+  "course_number": "4360",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "6241242fba30b4ebd5adc05a"
+  },
+  "course_number": "6347",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62411b6aba30b4ebd5adbeed"
+  },
+  "course_number": "6354",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6241263fba30b4ebd5adc09b"
+  },
+  "course_number": "3319",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62411b6bba30b4ebd5adbef0"
+  },
+  "course_number": "6355",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62412bd5ba30b4ebd5adc16f"
+  },
+  "course_number": "3100",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241207aba30b4ebd5adbfec"
+  },
+  "course_number": "6398",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624130d5ba30b4ebd5adc205"
+  },
+  "course_number": "3312",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "6241263eba30b4ebd5adc099"
+  },
+  "course_number": "3316",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62414932ba30b4ebd5adc3b8"
+  },
+  "course_number": "3342",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "62412640ba30b4ebd5adc0a3"
+  },
+  "course_number": "3377",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62414bbeba30b4ebd5adc429"
+  },
+  "course_number": "6381",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62412646ba30b4ebd5adc0b0"
+  },
+  "course_number": "4368",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62414eccba30b4ebd5adc4ae"
+  },
+  "course_number": "6323",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62412647ba30b4ebd5adc0b5"
+  },
+  "course_number": "4377",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62415318ba30b4ebd5adc4f8"
+  },
+  "course_number": "4312",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62414920ba30b4ebd5adc3b0"
+  },
+  "course_number": "1142",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "62415402ba30b4ebd5adc567"
+  },
+  "course_number": "7310",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "624157e2ba30b4ebd5adc5d0"
+  },
+  "course_number": "6304",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241588fba30b4ebd5adc629"
+  },
+  "course_number": "4317",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62415906ba30b4ebd5adc64c"
+  },
+  "course_number": "7375",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6242107dc9e4c7fafbcbf50e"
+  },
+  "course_number": "3359",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "624213a3c9e4c7fafbcbf541"
+  },
+  "course_number": "6370",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6242142ac9e4c7fafbcbf54a"
+  },
+  "course_number": "3328",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624218e0c9e4c7fafbcbf580"
+  },
+  "course_number": "4V50",
+  "subject_prefix": "ISAE"
+},{
+  "_id": {
+    "$oid": "62421cbcc9e4c7fafbcbf5b2"
+  },
+  "course_number": "3331",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240c228ba30b4ebd5adb77f"
+  },
+  "course_number": "3313",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "6240d111ba30b4ebd5adb807"
+  },
+  "course_number": "7110",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6240f702ba30b4ebd5adba99"
+  },
+  "course_number": "4V75",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "624106a8ba30b4ebd5adbc60"
+  },
+  "course_number": "6307",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62411588ba30b4ebd5adbe77"
+  },
+  "course_number": "6366",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62411ceeba30b4ebd5adbf49"
+  },
+  "course_number": "4315",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62411d5cba30b4ebd5adbf96"
+  },
+  "course_number": "7330",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62412036ba30b4ebd5adbfd4"
+  },
+  "course_number": "5311",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241298fba30b4ebd5adc0df"
+  },
+  "course_number": "3306",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "62412a6aba30b4ebd5adc143"
+  },
+  "course_number": "7349",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62412a83ba30b4ebd5adc14b"
+  },
+  "course_number": "6315",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62412cd3ba30b4ebd5adc196"
+  },
+  "course_number": "4310",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "624207cdc9e4c7fafbcbf490"
+  },
+  "course_number": "7V87",
+  "subject_prefix": "EEBM"
+},{
+  "_id": {
+    "$oid": "6241feeec9e4c7fafbcbf41f"
+  },
+  "course_number": "3309",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6241feffc9e4c7fafbcbf42a"
+  },
+  "course_number": "6313",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "6242107fc9e4c7fafbcbf510"
+  },
+  "course_number": "3382",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "6242110ac9e4c7fafbcbf518"
+  },
+  "course_number": "4300",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624211dcc9e4c7fafbcbf52d"
+  },
+  "course_number": "7363",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62421430c9e4c7fafbcbf54e"
+  },
+  "course_number": "4359",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62421433c9e4c7fafbcbf550"
+  },
+  "course_number": "6340",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624215f4c9e4c7fafbcbf562"
+  },
+  "course_number": "6374",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624223bac9e4c7fafbcbf66c"
+  },
+  "course_number": "4333",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "624226d8c9e4c7fafbcbf6c3"
+  },
+  "course_number": "5341",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62422b96c9e4c7fafbcbf700"
+  },
+  "course_number": "5341",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "62422df8c9e4c7fafbcbf733"
+  },
+  "course_number": "3340",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6240c03dba30b4ebd5adb748"
+  },
+  "course_number": "6347",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "6240e21bba30b4ebd5adb8ba"
+  },
+  "course_number": "6203",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240e220ba30b4ebd5adb8db"
+  },
+  "course_number": "7203",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240e2ecba30b4ebd5adb8f2"
+  },
+  "course_number": "6379",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "6240f55bba30b4ebd5adba59"
+  },
+  "course_number": "5314",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62410919ba30b4ebd5adbd2c"
+  },
+  "course_number": "7391",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241104cba30b4ebd5adbe23"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62411332ba30b4ebd5adbe4e"
+  },
+  "course_number": "6383",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "62411578ba30b4ebd5adbe6d"
+  },
+  "course_number": "6343",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62411cf8ba30b4ebd5adbf7d"
+  },
+  "course_number": "6330",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62411d5cba30b4ebd5adbf98"
+  },
+  "course_number": "7345",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62412646ba30b4ebd5adc0ae"
+  },
+  "course_number": "4360",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62412649ba30b4ebd5adc0bf"
+  },
+  "course_number": "6390",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624129e3ba30b4ebd5adc0f2"
+  },
+  "course_number": "3100",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "62412a69ba30b4ebd5adc138"
+  },
+  "course_number": "6345",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62412c4fba30b4ebd5adc187"
+  },
+  "course_number": "6341",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6241322eba30b4ebd5adc207"
+  },
+  "course_number": "1301",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "624132caba30b4ebd5adc22e"
+  },
+  "course_number": "3324",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62413fadba30b4ebd5adc36f"
+  },
+  "course_number": "4V91",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62413fb0ba30b4ebd5adc381"
+  },
+  "course_number": "6322",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62414bb1ba30b4ebd5adc3eb"
+  },
+  "course_number": "6332",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62414bbfba30b4ebd5adc430"
+  },
+  "course_number": "7310",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "62414f01ba30b4ebd5adc4b6"
+  },
+  "course_number": "6362",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62415402ba30b4ebd5adc565"
+  },
+  "course_number": "7306",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "62415906ba30b4ebd5adc64e"
+  },
+  "course_number": "7384",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62421532c9e4c7fafbcbf558"
+  },
+  "course_number": "6331",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "62420684c9e4c7fafbcbf450"
+  },
+  "course_number": "4396",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62421673c9e4c7fafbcbf566"
+  },
+  "course_number": "6327",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62420886c9e4c7fafbcbf492"
+  },
+  "course_number": "7325",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "624217e8c9e4c7fafbcbf57c"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62420cbfc9e4c7fafbcbf4b1"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "6242244ec9e4c7fafbcbf67b"
+  },
+  "course_number": "4090",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "62420f84c9e4c7fafbcbf509"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62422794c9e4c7fafbcbf6c7"
+  },
+  "course_number": "7V26",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "62421112c9e4c7fafbcbf51f"
+  },
+  "course_number": "6387",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6240bfd6ba30b4ebd5adb73e"
+  },
+  "course_number": "6334",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "624211d7c9e4c7fafbcbf529"
+  },
+  "course_number": "6387",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6240f58eba30b4ebd5adba63"
+  },
+  "course_number": "6V39",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6242131dc9e4c7fafbcbf538"
+  },
+  "course_number": "6315",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62412188ba30b4ebd5adc00d"
+  },
+  "course_number": "4310",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6242131fc9e4c7fafbcbf53a"
+  },
+  "course_number": "7376",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624121d9ba30b4ebd5adc029"
+  },
+  "course_number": "7364",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624221cac9e4c7fafbcbf641"
+  },
+  "course_number": "6336",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "624123b9ba30b4ebd5adc04a"
+  },
+  "course_number": "6317",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624221d5c9e4c7fafbcbf64d"
+  },
+  "course_number": "5326",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "624123beba30b4ebd5adc050"
+  },
+  "course_number": "6334",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62422336c9e4c7fafbcbf667"
+  },
+  "course_number": "6307",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6241263eba30b4ebd5adc094"
+  },
+  "course_number": "2384",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62422541c9e4c7fafbcbf699"
+  },
+  "course_number": "4350",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62412640ba30b4ebd5adc0a5"
+  },
+  "course_number": "4332",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62422547c9e4c7fafbcbf69e"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62412648ba30b4ebd5adc0b9"
+  },
+  "course_number": "6327",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62422551c9e4c7fafbcbf6a5"
+  },
+  "course_number": "6349",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62422d76c9e4c7fafbcbf72e"
+  },
+  "course_number": "6V92",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62412af9ba30b4ebd5adc165"
+  },
+  "course_number": "6330",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "6240c22eba30b4ebd5adb783"
+  },
+  "course_number": "3324",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "62412ccdba30b4ebd5adc192"
+  },
+  "course_number": "4301",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "6240d1d5ba30b4ebd5adb81e"
+  },
+  "course_number": "4V00",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "62412cd0ba30b4ebd5adc194"
+  },
+  "course_number": "4305",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62410754ba30b4ebd5adbcd8"
+  },
+  "course_number": "3335",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "62412cd7ba30b4ebd5adc198"
+  },
+  "course_number": "4311",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62410916ba30b4ebd5adbd1e"
+  },
+  "course_number": "6331",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62414928ba30b4ebd5adc3b3"
+  },
+  "course_number": "2252",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "62411435ba30b4ebd5adbe59"
+  },
+  "course_number": "6359",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "624153cfba30b4ebd5adc550"
+  },
+  "course_number": "4V75",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "624115b1ba30b4ebd5adbe7c"
+  },
+  "course_number": "6368",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62411b6aba30b4ebd5adbee9"
+  },
+  "course_number": "6323",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62411b6aba30b4ebd5adbeeb"
+  },
+  "course_number": "6352",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62411b6cba30b4ebd5adbef6"
+  },
+  "course_number": "7318",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "62411d5aba30b4ebd5adbf8b"
+  },
+  "course_number": "6366",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62412035ba30b4ebd5adbfd0"
+  },
+  "course_number": "5301",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62412648ba30b4ebd5adc0bb"
+  },
+  "course_number": "6332",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62412b00ba30b4ebd5adc16b"
+  },
+  "course_number": "6333",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "62414e29ba30b4ebd5adc464"
+  },
+  "course_number": "4336",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "62414e2aba30b4ebd5adc46b"
+  },
+  "course_number": "4370",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "62415360ba30b4ebd5adc521"
+  },
+  "course_number": "4V41",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "62420a7ec9e4c7fafbcbf49f"
+  },
+  "course_number": "6314",
+  "subject_prefix": "EEOP"
+},{
+  "_id": {
+    "$oid": "6242110cc9e4c7fafbcbf51b"
+  },
+  "course_number": "4399",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62421535c9e4c7fafbcbf55b"
+  },
+  "course_number": "6332",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6242254ac9e4c7fafbcbf6a0"
+  },
+  "course_number": "6300",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62422810c9e4c7fafbcbf6c9"
+  },
+  "course_number": "4357",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62422c31c9e4c7fafbcbf70e"
+  },
+  "course_number": "3376",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6240d118ba30b4ebd5adb80b"
+  },
+  "course_number": "7205",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6240e20eba30b4ebd5adb8b8"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240e21dba30b4ebd5adb8c7"
+  },
+  "course_number": "6371",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240f99cba30b4ebd5adbaf4"
+  },
+  "course_number": "4313",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6240fa65ba30b4ebd5adbb13"
+  },
+  "course_number": "3307",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62411573ba30b4ebd5adbe6b"
+  },
+  "course_number": "6340",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62412a69ba30b4ebd5adc13c"
+  },
+  "course_number": "6353",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62412a83ba30b4ebd5adc151"
+  },
+  "course_number": "7332",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62412c4fba30b4ebd5adc185"
+  },
+  "course_number": "6314",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62413fafba30b4ebd5adc379"
+  },
+  "course_number": "6310",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62415403ba30b4ebd5adc569"
+  },
+  "course_number": "7312",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "62415f87ba30b4ebd5adc6f2"
+  },
+  "course_number": "6312",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "62416389ba30b4ebd5adc7a2"
+  },
+  "course_number": "6317",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "62415fabba30b4ebd5adc6f8"
+  },
+  "course_number": "6341",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241598dba30b4ebd5adc655"
+  },
+  "course_number": "3328",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62416c2eba30b4ebd5adc87c"
+  },
+  "course_number": "3303",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62416c30ba30b4ebd5adc88e"
+  },
+  "course_number": "4375",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6241f278a698d6bd4b833c95"
+  },
+  "course_number": "4369",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6241fc30a698d6bd4b833d27"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "623ec513f0de8df66fd5e334"
+  },
+  "course_number": "6216",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "623ed1dcf0de8df66fd5e4be"
+  },
+  "course_number": "3306",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "623edaadf0de8df66fd5e59f"
+  },
+  "course_number": "6304",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "623edaadf0de8df66fd5e5a3"
+  },
+  "course_number": "6321",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "623ee61cfe75bccce55a110c"
+  },
+  "course_number": "6101",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623eef59fe75bccce55a11eb"
+  },
+  "course_number": "6318",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "623efedafe75bccce55a12d7"
+  },
+  "course_number": "5305",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "623f00ccfe75bccce55a12f7"
+  },
+  "course_number": "6313",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "623fd7b92e493a3184b493b1"
+  },
+  "course_number": "6374",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623fe4852e493a3184b4956d"
+  },
+  "course_number": "4340",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe4c22e493a3184b49572"
+  },
+  "course_number": "4364",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe53d2e493a3184b4957f"
+  },
+  "course_number": "4397",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe5892e493a3184b495b8"
+  },
+  "course_number": "6340",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6241611cba30b4ebd5adc723"
+  },
+  "course_number": "4359",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241611fba30b4ebd5adc736"
+  },
+  "course_number": "6321",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "624162fbba30b4ebd5adc786"
+  },
+  "course_number": "4352",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "62416c88ba30b4ebd5adc8a9"
+  },
+  "course_number": "3366",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6241e1caa698d6bd4b833aed"
+  },
+  "course_number": "7V89",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6241fde5a698d6bd4b833d32"
+  },
+  "course_number": "3327",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62420338a698d6bd4b833de1"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6242067fa698d6bd4b833e5d"
+  },
+  "course_number": "6318",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62420857a698d6bd4b833e91"
+  },
+  "course_number": "5333",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62420f2ba698d6bd4b833ef8"
+  },
+  "course_number": "4315",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "623ec50af0de8df66fd5e311"
+  },
+  "course_number": "2335",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec50df0de8df66fd5e321"
+  },
+  "course_number": "3315",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec50df0de8df66fd5e323"
+  },
+  "course_number": "3336",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec518f0de8df66fd5e33f"
+  },
+  "course_number": "1320",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "623ecaccf0de8df66fd5e41a"
+  },
+  "course_number": "3201",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623ed1faf0de8df66fd5e4de"
+  },
+  "course_number": "2340",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "623ed55df0de8df66fd5e56a"
+  },
+  "course_number": "3202",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ee61dfe75bccce55a1112"
+  },
+  "course_number": "6105",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623ee65afe75bccce55a1120"
+  },
+  "course_number": "6112",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623ef378fe75bccce55a1225"
+  },
+  "course_number": "6351",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "623efca3fe75bccce55a1292"
+  },
+  "course_number": "6308",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623fd83c2e493a3184b493d6"
+  },
+  "course_number": "6368",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623fd9332e493a3184b493f2"
+  },
+  "course_number": "4307",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "623fdd3a2e493a3184b4945d"
+  },
+  "course_number": "3315",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "623fe3cb2e493a3184b49552"
+  },
+  "course_number": "3372",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe4842e493a3184b4956b"
+  },
+  "course_number": "4338",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe5882e493a3184b495b2"
+  },
+  "course_number": "6311",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62415fbbba30b4ebd5adc702"
+  },
+  "course_number": "6392",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241609cba30b4ebd5adc719"
+  },
+  "course_number": "4307",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416725ba30b4ebd5adc7fc"
+  },
+  "course_number": "5339",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "62416e9aba30b4ebd5adc8f0"
+  },
+  "course_number": "6332",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241e7d2a698d6bd4b833b71"
+  },
+  "course_number": "4336",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241e7dca698d6bd4b833bb3"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241f4aca698d6bd4b833cba"
+  },
+  "course_number": "8V97",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62420345a698d6bd4b833dfa"
+  },
+  "course_number": "5302",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6242068aa698d6bd4b833e66"
+  },
+  "course_number": "8330",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62420cd0a698d6bd4b833eca"
+  },
+  "course_number": "5324",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "62420cd3a698d6bd4b833ecc"
+  },
+  "course_number": "5333",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "623ec90ff0de8df66fd5e3d0"
+  },
+  "course_number": "3402",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ec98ef0de8df66fd5e3e5"
+  },
+  "course_number": "4395",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "623ed20af0de8df66fd5e50b"
+  },
+  "course_number": "4376",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "623ed5d8f0de8df66fd5e580"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ee61cfe75bccce55a1110"
+  },
+  "course_number": "6103",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623efca2fe75bccce55a1290"
+  },
+  "course_number": "3337",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623efed9fe75bccce55a12d3"
+  },
+  "course_number": "3351",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "623f010afe75bccce55a1307"
+  },
+  "course_number": "6382",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "623fdaf22e493a3184b4942a"
+  },
+  "course_number": "4379",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "623fdd7c2e493a3184b4947f"
+  },
+  "course_number": "3382",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "623fe4082e493a3184b49559"
+  },
+  "course_number": "3382",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe58a2e493a3184b495c0"
+  },
+  "course_number": "6698",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fef5b2e493a3184b49709"
+  },
+  "course_number": "4325",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62415993ba30b4ebd5adc659"
+  },
+  "course_number": "4330",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62415f55ba30b4ebd5adc6e6"
+  },
+  "course_number": "5336",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6241607fba30b4ebd5adc70e"
+  },
+  "course_number": "3327",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241609fba30b4ebd5adc71b"
+  },
+  "course_number": "4308",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416ea0ba30b4ebd5adc8fa"
+  },
+  "course_number": "7331",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241786dba30b4ebd5adc9da"
+  },
+  "course_number": "3324",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241dac2a698d6bd4b833a03"
+  },
+  "course_number": "5324",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241f77ba698d6bd4b833ce7"
+  },
+  "course_number": "6320",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62420857a698d6bd4b833e8e"
+  },
+  "course_number": "4399",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "623eca0ef0de8df66fd5e3fd"
+  },
+  "course_number": "6359",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "623ecacbf0de8df66fd5e418"
+  },
+  "course_number": "3161",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623ecb09f0de8df66fd5e41e"
+  },
+  "course_number": "3202",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623ecb89f0de8df66fd5e43e"
+  },
+  "course_number": "4V97",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623edaadf0de8df66fd5e5a1"
+  },
+  "course_number": "6310",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "623ee61efe75bccce55a1118"
+  },
+  "course_number": "6108",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623ee65afe75bccce55a1122"
+  },
+  "course_number": "6113",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623fd7bc2e493a3184b493c1"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623fda332e493a3184b49413"
+  },
+  "course_number": "6302",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "623fdd752e493a3184b49466"
+  },
+  "course_number": "3364",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "623fe4082e493a3184b49556"
+  },
+  "course_number": "3380",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe5832e493a3184b4959f"
+  },
+  "course_number": "4399",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62415991ba30b4ebd5adc657"
+  },
+  "course_number": "4324",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62416081ba30b4ebd5adc717"
+  },
+  "course_number": "4304",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "624160f3ba30b4ebd5adc71d"
+  },
+  "course_number": "4310",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416117ba30b4ebd5adc71f"
+  },
+  "course_number": "4316",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416c31ba30b4ebd5adc892"
+  },
+  "course_number": "4386",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62416e66ba30b4ebd5adc8e9"
+  },
+  "course_number": "5353",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241e7d7a698d6bd4b833b8e"
+  },
+  "course_number": "5375",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "62420690a698d6bd4b833e6d"
+  },
+  "course_number": "8332",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62420910a698d6bd4b833e97"
+  },
+  "course_number": "8V97",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "623ec509f0de8df66fd5e30b"
+  },
+  "course_number": "2321",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec51ef0de8df66fd5e341"
+  },
+  "course_number": "3300",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "623ec55bf0de8df66fd5e34f"
+  },
+  "course_number": "4300",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "623ed1ddf0de8df66fd5e4c1"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "623ed55bf0de8df66fd5e566"
+  },
+  "course_number": "3201",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ed5d6f0de8df66fd5e579"
+  },
+  "course_number": "4203",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ee61cfe75bccce55a110e"
+  },
+  "course_number": "6102",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623ef813fe75bccce55a1260"
+  },
+  "course_number": "4304",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "623fda322e493a3184b4940e"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "623fe2ff2e493a3184b49503"
+  },
+  "course_number": "2322",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe6452e493a3184b495d6"
+  },
+  "course_number": "7253",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "62415f56ba30b4ebd5adc6ee"
+  },
+  "course_number": "6383",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62416080ba30b4ebd5adc713"
+  },
+  "course_number": "3353",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241611fba30b4ebd5adc738"
+  },
+  "course_number": "6338",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416120ba30b4ebd5adc73c"
+  },
+  "course_number": "6352",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416c30ba30b4ebd5adc88a"
+  },
+  "course_number": "4317",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "624170e4ba30b4ebd5adc92f"
+  },
+  "course_number": "6327",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "62417891ba30b4ebd5adc9dc"
+  },
+  "course_number": "3342",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241d902a698d6bd4b833964"
+  },
+  "course_number": "6V81",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62420346a698d6bd4b833dfd"
+  },
+  "course_number": "5322",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6242068da698d6bd4b833e6a"
+  },
+  "course_number": "8331",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62420857a698d6bd4b833e94"
+  },
+  "course_number": "8V70",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "623ec911f0de8df66fd5e3da"
+  },
+  "course_number": "4V97",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ee61dfe75bccce55a1114"
+  },
+  "course_number": "6106",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623f00cdfe75bccce55a12ff"
+  },
+  "course_number": "6341",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "623fd83c2e493a3184b493d4"
+  },
+  "course_number": "6367",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623fdab62e493a3184b4941e"
+  },
+  "course_number": "3327",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "623fdd372e493a3184b4945b"
+  },
+  "course_number": "3311",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "623fe3082e493a3184b4952b"
+  },
+  "course_number": "3325",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe4462e493a3184b49562"
+  },
+  "course_number": "4317",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe5002e493a3184b4957b"
+  },
+  "course_number": "4377",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe8ff2e493a3184b49631"
+  },
+  "course_number": "3310",
+  "subject_prefix": "BBSU"
+},{
+  "_id": {
+    "$oid": "62415f50ba30b4ebd5adc6cb"
+  },
+  "course_number": "3427",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62415f55ba30b4ebd5adc6ea"
+  },
+  "course_number": "5392",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "62415f5cba30b4ebd5adc6f0"
+  },
+  "course_number": "4310",
+  "subject_prefix": "PPOL"
+},{
+  "_id": {
+    "$oid": "62415fa6ba30b4ebd5adc6f6"
+  },
+  "course_number": "6338",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "62415fb8ba30b4ebd5adc700"
+  },
+  "course_number": "6370",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "62416120ba30b4ebd5adc73e"
+  },
+  "course_number": "7372",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62416c2eba30b4ebd5adc87e"
+  },
+  "course_number": "3320",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62416c32ba30b4ebd5adc898"
+  },
+  "course_number": "6357",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62416e9fba30b4ebd5adc8f6"
+  },
+  "course_number": "6340",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "62416ea0ba30b4ebd5adc8f8"
+  },
+  "course_number": "6347",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "624170e0ba30b4ebd5adc91f"
+  },
+  "course_number": "6315",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "6241789bba30b4ebd5adc9e2"
+  },
+  "course_number": "3380",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241e7dda698d6bd4b833bbb"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "6241f5b4a698d6bd4b833cce"
+  },
+  "course_number": "4315",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6241f6baa698d6bd4b833cde"
+  },
+  "course_number": "6329",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624205f4a698d6bd4b833e46"
+  },
+  "course_number": "6354",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "623ec509f0de8df66fd5e309"
+  },
+  "course_number": "2310",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec50af0de8df66fd5e30e"
+  },
+  "course_number": "2330",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec910f0de8df66fd5e3d3"
+  },
+  "course_number": "4301",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ee61efe75bccce55a111c"
+  },
+  "course_number": "6110",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623fd9332e493a3184b493ed"
+  },
+  "course_number": "4303",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "623fd9342e493a3184b493f6"
+  },
+  "course_number": "4309",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "623fda322e493a3184b49410"
+  },
+  "course_number": "6301",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "623fda332e493a3184b49416"
+  },
+  "course_number": "6310",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "623fe58a2e493a3184b495be"
+  },
+  "course_number": "6380",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe6072e493a3184b495c6"
+  },
+  "course_number": "6114",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "623fee152e493a3184b496e0"
+  },
+  "course_number": "3355",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62415fb3ba30b4ebd5adc6fe"
+  },
+  "course_number": "6369",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6241611cba30b4ebd5adc725"
+  },
+  "course_number": "4363",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "624162feba30b4ebd5adc794"
+  },
+  "course_number": "4V75",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "62416c31ba30b4ebd5adc894"
+  },
+  "course_number": "6312",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62416d8dba30b4ebd5adc8cf"
+  },
+  "course_number": "4V75",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "62416e97ba30b4ebd5adc8ee"
+  },
+  "course_number": "6329",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "623ec4e6f0de8df66fd5e2ca"
+  },
+  "course_number": "6313",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623ec510f0de8df66fd5e332"
+  },
+  "course_number": "4384",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ec7d6f0de8df66fd5e3af"
+  },
+  "course_number": "2190",
+  "subject_prefix": "BIS"
+},{
+  "_id": {
+    "$oid": "623ecb86f0de8df66fd5e431"
+  },
+  "course_number": "4203",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623ed55af0de8df66fd5e564"
+  },
+  "course_number": "3161",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ee61dfe75bccce55a1116"
+  },
+  "course_number": "6107",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623ee61efe75bccce55a111a"
+  },
+  "course_number": "6109",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623eef58fe75bccce55a11e5"
+  },
+  "course_number": "6307",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "623ef4f1fe75bccce55a124c"
+  },
+  "course_number": "6335",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "623efbe8fe75bccce55a1284"
+  },
+  "course_number": "3348",
+  "subject_prefix": "LANG"
+},{
+  "_id": {
+    "$oid": "623fd8b62e493a3184b493e5"
+  },
+  "course_number": "7310",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623fd8b72e493a3184b493e9"
+  },
+  "course_number": "7320",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623fdab72e493a3184b49425"
+  },
+  "course_number": "4324",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "623fe57b2e493a3184b49584"
+  },
+  "course_number": "4398",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe5862e493a3184b495a8"
+  },
+  "course_number": "4V96",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe5872e493a3184b495ae"
+  },
+  "course_number": "6001",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe8032e493a3184b49608"
+  },
+  "course_number": "1100",
+  "subject_prefix": "BBSU"
+},{
+  "_id": {
+    "$oid": "623fedd72e493a3184b496d7"
+  },
+  "course_number": "3312",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62402c302e493a3184b49c50"
+  },
+  "course_number": "6362",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "623fef9c2e493a3184b49726"
+  },
+  "course_number": "6343",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "623ffc122e493a3184b498c2"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "623ff7db2e493a3184b497fa"
+  },
+  "course_number": "6347",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "624008892e493a3184b49a18"
+  },
+  "course_number": "4371",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "62401b5a2e493a3184b49b15"
+  },
+  "course_number": "4334",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62402c252e493a3184b49c4a"
+  },
+  "course_number": "3302",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "62402c2c2e493a3184b49c4e"
+  },
+  "course_number": "6332",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "62402ff12e493a3184b49c97"
+  },
+  "course_number": "6355",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624035452e493a3184b49cac"
+  },
+  "course_number": "3200",
+  "subject_prefix": "EPCS"
+},{
+  "_id": {
+    "$oid": "624035552e493a3184b49ccf"
+  },
+  "course_number": "7386",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6240355b2e493a3184b49cd3"
+  },
+  "course_number": "1303",
+  "subject_prefix": "FILM"
+},{
+  "_id": {
+    "$oid": "624035ba2e493a3184b49d3f"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624039f92e493a3184b49db9"
+  },
+  "course_number": "4381",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62403bfb2e493a3184b49df8"
+  },
+  "course_number": "6343",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62403e752e493a3184b49e5a"
+  },
+  "course_number": "3366",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624041952e493a3184b49edc"
+  },
+  "course_number": "3111",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "624041a92e493a3184b49ef6"
+  },
+  "course_number": "6310",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "62404ea02e493a3184b4a033"
+  },
+  "course_number": "8V83",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "6240d9ee21d1cb6c9f3c64d4"
+  },
+  "course_number": "6308",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240ddfd21d1cb6c9f3c657f"
+  },
+  "course_number": "6383",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240f9a61d567db1444ad2b6"
+  },
+  "course_number": "6325",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240f9ac1d567db1444ad2bb"
+  },
+  "course_number": "5325",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6240facd1d567db1444ad2fd"
+  },
+  "course_number": "4322",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "624106861d567db1444ad426"
+  },
+  "course_number": "6325",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624112af1d567db1444ad5ce"
+  },
+  "course_number": "3336",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "62411ff61d567db1444ad79e"
+  },
+  "course_number": "6325",
+  "subject_prefix": "SYSE"
+},{
+  "_id": {
+    "$oid": "624126251d567db1444ad884"
+  },
+  "course_number": "4076",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "624127281d567db1444ad88a"
+  },
+  "course_number": "3300",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "624127351d567db1444ad88f"
+  },
+  "course_number": "4V99",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "62403644ddc4b627a73bfaad"
+  },
+  "course_number": "6110",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "624036a0ddc4b627a73bfada"
+  },
+  "course_number": "7372",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "62403930ddc4b627a73bfb20"
+  },
+  "course_number": "3322",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "624043d6ddc4b627a73bfc40"
+  },
+  "course_number": "4316",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624043dcddc4b627a73bfc5b"
+  },
+  "course_number": "4375",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240451eddc4b627a73bfcae"
+  },
+  "course_number": "6327",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62405023ddc4b627a73bfde8"
+  },
+  "course_number": "4357",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62403a362e493a3184b49dc5"
+  },
+  "course_number": "6323",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62403c352e493a3184b49e01"
+  },
+  "course_number": "6367",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62403dfa2e493a3184b49e49"
+  },
+  "course_number": "2381",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62403e372e493a3184b49e4f"
+  },
+  "course_number": "3312",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624041822e493a3184b49ec1"
+  },
+  "course_number": "6325",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624041962e493a3184b49ee0"
+  },
+  "course_number": "3113",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "6240487b2e493a3184b49fd0"
+  },
+  "course_number": "4381",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "62404ea02e493a3184b4a02f"
+  },
+  "course_number": "6105",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "6240f9a31d567db1444ad2a9"
+  },
+  "course_number": "3301",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240fa831d567db1444ad2e3"
+  },
+  "course_number": "3112",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240ff8d1d567db1444ad3a6"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241067d1d567db1444ad41a"
+  },
+  "course_number": "6305",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624107ab1d567db1444ad492"
+  },
+  "course_number": "6319",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "624108741d567db1444ad4b9"
+  },
+  "course_number": "4322",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "624111a31d567db1444ad5aa"
+  },
+  "course_number": "7330",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241163e1d567db1444ad68d"
+  },
+  "course_number": "4303",
+  "subject_prefix": "RHET"
+},{
+  "_id": {
+    "$oid": "6241243e1d567db1444ad841"
+  },
+  "course_number": "4361",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624006322e493a3184b499af"
+  },
+  "course_number": "6221",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624006342e493a3184b499b4"
+  },
+  "course_number": "6305",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624006772e493a3184b499c1"
+  },
+  "course_number": "7204",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624006bb2e493a3184b499d4"
+  },
+  "course_number": "7V82",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624027e72e493a3184b49c08"
+  },
+  "course_number": "6397",
+  "subject_prefix": "EEGR"
+},{
+  "_id": {
+    "$oid": "62402ffb2e493a3184b49ca7"
+  },
+  "course_number": "7301",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624035442e493a3184b49caa"
+  },
+  "course_number": "2200",
+  "subject_prefix": "EPCS"
+},{
+  "_id": {
+    "$oid": "624039fa2e493a3184b49dbf"
+  },
+  "course_number": "4V96",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62403a372e493a3184b49dc9"
+  },
+  "course_number": "6363",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6240dad321d1cb6c9f3c6502"
+  },
+  "course_number": "6345",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6240dcb021d1cb6c9f3c6521"
+  },
+  "course_number": "6305",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240ddf321d1cb6c9f3c6558"
+  },
+  "course_number": "6349",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240f9741d567db1444ad26f"
+  },
+  "course_number": "4337",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240f9851d567db1444ad2a0"
+  },
+  "course_number": "6353",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240f9871d567db1444ad2a7"
+  },
+  "course_number": "7316",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240fabb1d567db1444ad2eb"
+  },
+  "course_number": "3122",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6241068a1d567db1444ad42e"
+  },
+  "course_number": "6334",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241068d1d567db1444ad436"
+  },
+  "course_number": "6343",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241069b1d567db1444ad455"
+  },
+  "course_number": "6382",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624106a61d567db1444ad46f"
+  },
+  "course_number": "7330",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624108431d567db1444ad4af"
+  },
+  "course_number": "1305",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "624108501d567db1444ad4b7"
+  },
+  "course_number": "3323",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62410d621d567db1444ad54c"
+  },
+  "course_number": "4396",
+  "subject_prefix": "PPOL"
+},{
+  "_id": {
+    "$oid": "62410df81d567db1444ad558"
+  },
+  "course_number": "6343",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "624113c91d567db1444ad62d"
+  },
+  "course_number": "4328",
+  "subject_prefix": "REAL"
+},{
+  "_id": {
+    "$oid": "62411b681d567db1444ad72a"
+  },
+  "course_number": "6370",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62411f691d567db1444ad76d"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "624126221d567db1444ad881"
+  },
+  "course_number": "3310",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "624043d4ddc4b627a73bfc38"
+  },
+  "course_number": "4307",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240451fddc4b627a73bfcb2"
+  },
+  "course_number": "6376",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240451fddc4b627a73bfcb4"
+  },
+  "course_number": "6383",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62404520ddc4b627a73bfcb6"
+  },
+  "course_number": "6387",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62404521ddc4b627a73bfcbe"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624005b32e493a3184b499aa"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6240067a2e493a3184b499c4"
+  },
+  "course_number": "7219",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624006b62e493a3184b499d0"
+  },
+  "course_number": "7324",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "62401b642e493a3184b49b32"
+  },
+  "course_number": "8V02",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624029702e493a3184b49c13"
+  },
+  "course_number": "7354",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "624035522e493a3184b49cbd"
+  },
+  "course_number": "3310",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624035952e493a3184b49d1f"
+  },
+  "course_number": "4307",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624041962e493a3184b49ede"
+  },
+  "course_number": "3112",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "624041b32e493a3184b49f0c"
+  },
+  "course_number": "6346",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "62404ab92e493a3184b49ff5"
+  },
+  "course_number": "2329",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240d9ed21d1cb6c9f3c64cc"
+  },
+  "course_number": "5373",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240d9f021d1cb6c9f3c64dc"
+  },
+  "course_number": "6325",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240d9f021d1cb6c9f3c64de"
+  },
+  "course_number": "6335",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240d9f221d1cb6c9f3c64e8"
+  },
+  "course_number": "6358",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240da0221d1cb6c9f3c64ee"
+  },
+  "course_number": "6V96",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240f9751d567db1444ad275"
+  },
+  "course_number": "4360",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240fabd1d567db1444ad2ed"
+  },
+  "course_number": "3181",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "624108771d567db1444ad4bb"
+  },
+  "course_number": "4325",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62411fe21d567db1444ad785"
+  },
+  "course_number": "4360",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6241272d1d567db1444ad88c"
+  },
+  "course_number": "3340",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "62403898ddc4b627a73bfb0f"
+  },
+  "course_number": "6322",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "62404521ddc4b627a73bfcbc"
+  },
+  "course_number": "8305",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62405021ddc4b627a73bfddd"
+  },
+  "course_number": "3V91",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "623ff3c12e493a3184b497bc"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fef822e493a3184b49718"
+  },
+  "course_number": "5312",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62400cf32e493a3184b49a69"
+  },
+  "course_number": "3330",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62401b572e493a3184b49b0c"
+  },
+  "course_number": "3381",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "624029732e493a3184b49c15"
+  },
+  "course_number": "7356",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "6240355e2e493a3184b49cdf"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "FILM"
+},{
+  "_id": {
+    "$oid": "624036762e493a3184b49d67"
+  },
+  "course_number": "6392",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62403df92e493a3184b49e45"
+  },
+  "course_number": "2370",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62403e792e493a3184b49e6c"
+  },
+  "course_number": "6330",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240417e2e493a3184b49eb2"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624041952e493a3184b49eda"
+  },
+  "course_number": "3108",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "624041962e493a3184b49ee2"
+  },
+  "course_number": "3114",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "624044b62e493a3184b49f6b"
+  },
+  "course_number": "4307",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "62404af42e493a3184b49fff"
+  },
+  "course_number": "2350",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62404ea02e493a3184b4a031"
+  },
+  "course_number": "6V09",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "6240ddfe21d1cb6c9f3c6581"
+  },
+  "course_number": "6384",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6241068c1d567db1444ad432"
+  },
+  "course_number": "6340",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624107421d567db1444ad484"
+  },
+  "course_number": "3382",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62410cdb1d567db1444ad545"
+  },
+  "course_number": "8V20",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "624112d11d567db1444ad606"
+  },
+  "course_number": "4365",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6240451eddc4b627a73bfcaa"
+  },
+  "course_number": "6315",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240451fddc4b627a73bfcb0"
+  },
+  "course_number": "6357",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62404521ddc4b627a73bfcba"
+  },
+  "course_number": "6399",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62405022ddc4b627a73bfddf"
+  },
+  "course_number": "4305",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "623ff3ad2e493a3184b49798"
+  },
+  "course_number": "6330",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ff3b12e493a3184b497a0"
+  },
+  "course_number": "6366",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ff3b42e493a3184b497a7"
+  },
+  "course_number": "6379",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ff3b92e493a3184b497af"
+  },
+  "course_number": "6395",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62400cf82e493a3184b49a70"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "624029f22e493a3184b49c1b"
+  },
+  "course_number": "6393",
+  "subject_prefix": "EERF"
+},{
+  "_id": {
+    "$oid": "6240359a2e493a3184b49d31"
+  },
+  "course_number": "4338",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62403c372e493a3184b49e03"
+  },
+  "course_number": "6368",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62403c382e493a3184b49e05"
+  },
+  "course_number": "6373",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62403e782e493a3184b49e68"
+  },
+  "course_number": "4382",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624041942e493a3184b49ed6"
+  },
+  "course_number": "3101",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "62404ab92e493a3184b49ff2"
+  },
+  "course_number": "2321",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240f9a31d567db1444ad2ac"
+  },
+  "course_number": "3310",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240fa571d567db1444ad2ca"
+  },
+  "course_number": "2129",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240faa81d567db1444ad2e5"
+  },
+  "course_number": "3116",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "624106901d567db1444ad43b"
+  },
+  "course_number": "6359",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6241117a1d567db1444ad580"
+  },
+  "course_number": "3364",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "624112a11d567db1444ad5c3"
+  },
+  "course_number": "3322",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "62411b261d567db1444ad715"
+  },
+  "course_number": "3382",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "62403894ddc4b627a73bfb0c"
+  },
+  "course_number": "6321",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "624043d8ddc4b627a73bfc47"
+  },
+  "course_number": "4322",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240451dddc4b627a73bfca6"
+  },
+  "course_number": "6301",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624045f0ddc4b627a73bfcda"
+  },
+  "course_number": "8V97",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "623ff1522e493a3184b4974f"
+  },
+  "course_number": "4301",
+  "subject_prefix": "BLAW"
+},{
+  "_id": {
+    "$oid": "623ff3ac2e493a3184b49796"
+  },
+  "course_number": "6321",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ff8332e493a3184b49816"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "624006b12e493a3184b499cc"
+  },
+  "course_number": "7305",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624006c32e493a3184b499da"
+  },
+  "course_number": "7V98",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624026a22e493a3184b49bee"
+  },
+  "course_number": "7326",
+  "subject_prefix": "EECT"
+},{
+  "_id": {
+    "$oid": "62402a802e493a3184b49c29"
+  },
+  "course_number": "6364",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62402c212e493a3184b49c47"
+  },
+  "course_number": "3301",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "624035972e493a3184b49d27"
+  },
+  "course_number": "4328",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62403c762e493a3184b49e10"
+  },
+  "course_number": "7311",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624041942e493a3184b49ed8"
+  },
+  "course_number": "3104",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "624041ad2e493a3184b49f06"
+  },
+  "course_number": "7320",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624041b42e493a3184b49f0e"
+  },
+  "course_number": "6355",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624043f72e493a3184b49f4d"
+  },
+  "course_number": "4335",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624044372e493a3184b49f61"
+  },
+  "course_number": "6362",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624049b52e493a3184b49fe6"
+  },
+  "course_number": "4348",
+  "subject_prefix": "LANG"
+},{
+  "_id": {
+    "$oid": "6240d9ec21d1cb6c9f3c64ca"
+  },
+  "course_number": "5300",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240fabf1d567db1444ad2ef"
+  },
+  "course_number": "3185",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240fac31d567db1444ad2f3"
+  },
+  "course_number": "3229",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "624116cc1d567db1444ad698"
+  },
+  "course_number": "4338",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "6241243f1d567db1444ad843"
+  },
+  "course_number": "4365",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "624124501d567db1444ad853"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "TE"
+},{
+  "_id": {
+    "$oid": "623ff39d2e493a3184b49789"
+  },
+  "course_number": "4370",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624006b42e493a3184b499ce"
+  },
+  "course_number": "7309",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "624018ee2e493a3184b49aef"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624036742e493a3184b49d5e"
+  },
+  "course_number": "6357",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624039f82e493a3184b49db7"
+  },
+  "course_number": "4363",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62403df92e493a3184b49e43"
+  },
+  "course_number": "2340",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62403e752e493a3184b49e58"
+  },
+  "course_number": "3344",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624041632e493a3184b49e9c"
+  },
+  "course_number": "4306",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "624041862e493a3184b49ed4"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240db6121d1cb6c9f3c650f"
+  },
+  "course_number": "180",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6240f9a61d567db1444ad2b9"
+  },
+  "course_number": "6381",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240fac11d567db1444ad2f1"
+  },
+  "course_number": "3186",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240fac91d567db1444ad2f9"
+  },
+  "course_number": "3380",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240fc6e1d567db1444ad322"
+  },
+  "course_number": "1142",
+  "subject_prefix": "NATS"
+},{
+  "_id": {
+    "$oid": "6240fdba1d567db1444ad369"
+  },
+  "course_number": "4364",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6240ff881d567db1444ad3a2"
+  },
+  "course_number": "4337",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6241117d1d567db1444ad582"
+  },
+  "course_number": "4313",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "624113111d567db1444ad620"
+  },
+  "course_number": "6367",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "624113141d567db1444ad622"
+  },
+  "course_number": "6368",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "62411bfd1d567db1444ad738"
+  },
+  "course_number": "3330",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "624043cdddc4b627a73bfc13"
+  },
+  "course_number": "3357",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624043d3ddc4b627a73bfc2d"
+  },
+  "course_number": "3381",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624043d6ddc4b627a73bfc3e"
+  },
+  "course_number": "4315",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624043daddc4b627a73bfc52"
+  },
+  "course_number": "4345",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62404520ddc4b627a73bfcb8"
+  },
+  "course_number": "6388",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62405029ddc4b627a73bfe0a"
+  },
+  "course_number": "6344",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62406c20ddc4b627a73c0027"
+  },
+  "course_number": "7V73",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "62408606ddc4b627a73c0313"
+  },
+  "course_number": "6V88",
+  "subject_prefix": "EEGR"
+},{
+  "_id": {
+    "$oid": "6240851eddc4b627a73c02f5"
+  },
+  "course_number": "6324",
+  "subject_prefix": "EECS"
+},{
+  "_id": {
+    "$oid": "62405f7cddc4b627a73bff9b"
+  },
+  "course_number": "3342",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "62406e70ddc4b627a73c0092"
+  },
+  "course_number": "7307",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62409658ddc4b627a73c04e6"
+  },
+  "course_number": "5313",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62409417ddc4b627a73c044e"
+  },
+  "course_number": "4080",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62409be6ddc4b627a73c059b"
+  },
+  "course_number": "2341",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62409a9bddc4b627a73c0579"
+  },
+  "course_number": "6330",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "6240a10cddc4b627a73c0665"
+  },
+  "course_number": "7340",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6240bc98ddc4b627a73c0983"
+  },
+  "course_number": "4V98",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240b70fddc4b627a73c08fc"
+  },
+  "course_number": "6343",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6240bc98ddc4b627a73c0985"
+  },
+  "course_number": "5V95",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240bc9bddc4b627a73c0993"
+  },
+  "course_number": "6324",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240bc9eddc4b627a73c09a0"
+  },
+  "course_number": "6341",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240c7ecddc4b627a73c0b31"
+  },
+  "course_number": "4185",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240c050ddc4b627a73c0a11"
+  },
+  "course_number": "6343",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240d6c3ddc4b627a73c0d4f"
+  },
+  "course_number": "5395",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6240c7ebddc4b627a73c0b29"
+  },
+  "course_number": "4112",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240f6abddc4b627a73c10a7"
+  },
+  "course_number": "3351",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "623fb16c48c0b7b7e6837594"
+  },
+  "course_number": "2315",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240cf19ddc4b627a73c0cb2"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "623fc5d148c0b7b7e6837853"
+  },
+  "course_number": "7300",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "6240e3fbddc4b627a73c0f01"
+  },
+  "course_number": "4396",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "623fc7d648c0b7b7e68378a1"
+  },
+  "course_number": "1100",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6241774d4f665f12b9425ddb"
+  },
+  "course_number": "4V97",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ffa0f35f5a269783ff77f"
+  },
+  "course_number": "7300",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "624198544f665f12b94260ee"
+  },
+  "course_number": "4341",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240068335f5a269783ff949"
+  },
+  "course_number": "2350",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fa9605647dcaa6c0cb0b2"
+  },
+  "course_number": "6396",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "6240073d35f5a269783ff96b"
+  },
+  "course_number": "4383",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fb26448c0b7b7e68375b9"
+  },
+  "course_number": "3303",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240d78fe7c58a91f6b64ab0"
+  },
+  "course_number": "4339",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "623fb31f48c0b7b7e68375d1"
+  },
+  "course_number": "3312",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240e9b9d374e3c585977a07"
+  },
+  "course_number": "4327",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "623fb42b48c0b7b7e6837644"
+  },
+  "course_number": "6313",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240e9bad374e3c585977a0d"
+  },
+  "course_number": "6314",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "623fb42f48c0b7b7e6837656"
+  },
+  "course_number": "8307",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240eb91d374e3c585977a92"
+  },
+  "course_number": "5327",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6240073e35f5a269783ff975"
+  },
+  "course_number": "6342",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240eb93d374e3c585977a96"
+  },
+  "course_number": "5377",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6240093635f5a269783ff9c5"
+  },
+  "course_number": "3320",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240097335f5a269783ff9cd"
+  },
+  "course_number": "6311",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240145b35f5a269783ffab1"
+  },
+  "course_number": "5348",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240149835f5a269783ffab7"
+  },
+  "course_number": "6321",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240dd2de7c58a91f6b64b4c"
+  },
+  "course_number": "4193",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6240dda1e7c58a91f6b64b68"
+  },
+  "course_number": "4360",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "62409429ddc4b627a73c04aa"
+  },
+  "course_number": "7340",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62409484ddc4b627a73c04ba"
+  },
+  "course_number": "4309",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "62409995ddc4b627a73c0545"
+  },
+  "course_number": "6110",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6240a128ddc4b627a73c066b"
+  },
+  "course_number": "6323",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6240a264ddc4b627a73c06b5"
+  },
+  "course_number": "6091",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6240a943ddc4b627a73c077a"
+  },
+  "course_number": "3336",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240bcaeddc4b627a73c09b0"
+  },
+  "course_number": "6V69",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240c354ddc4b627a73c0abe"
+  },
+  "course_number": "3302",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240cee7ddc4b627a73c0ca6"
+  },
+  "course_number": "3309",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240cee9ddc4b627a73c0ca8"
+  },
+  "course_number": "3320",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240e392ddc4b627a73c0ecb"
+  },
+  "course_number": "4376",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6241654e4f665f12b9425ae7"
+  },
+  "course_number": "6350",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "624186134f665f12b9425edf"
+  },
+  "course_number": "6330",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "624187db4f665f12b9425ef7"
+  },
+  "course_number": "6V91",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "62418e4d4f665f12b9425fc6"
+  },
+  "course_number": "7393",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "623fb42548c0b7b7e683762d"
+  },
+  "course_number": "4368",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fc74e48c0b7b7e6837895"
+  },
+  "course_number": "6392",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "6240062a35f5a269783ff8e7"
+  },
+  "course_number": "6327",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6240073c35f5a269783ff966"
+  },
+  "course_number": "4369",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240073d35f5a269783ff96d"
+  },
+  "course_number": "4388",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62400bed35f5a269783ffa19"
+  },
+  "course_number": "6300",
+  "subject_prefix": "IDEA"
+},{
+  "_id": {
+    "$oid": "6240145935f5a269783ffaaf"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240149935f5a269783ffac2"
+  },
+  "course_number": "7360",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240d7d4e7c58a91f6b64ade"
+  },
+  "course_number": "6372",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240d85ae7c58a91f6b64af5"
+  },
+  "course_number": "5377",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240e317e7c58a91f6b64c13"
+  },
+  "course_number": "4353",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240ec8cd374e3c585977a9c"
+  },
+  "course_number": "6302",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6240ec8dd374e3c585977aa0"
+  },
+  "course_number": "6340",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "62409419ddc4b627a73c0455"
+  },
+  "course_number": "4303",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6240a129ddc4b627a73c0673"
+  },
+  "course_number": "7313",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6240bc9eddc4b627a73c09a2"
+  },
+  "course_number": "6342",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240bc9fddc4b627a73c09a6"
+  },
+  "course_number": "6355",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240be3fddc4b627a73c09df"
+  },
+  "course_number": "4342",
+  "subject_prefix": "MILS"
+},{
+  "_id": {
+    "$oid": "6240c7e7ddc4b627a73c0b15"
+  },
+  "course_number": "2329",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240ceedddc4b627a73c0caa"
+  },
+  "course_number": "3324",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240e636ddc4b627a73c0f58"
+  },
+  "course_number": "4355",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "62418d944f665f12b9425f61"
+  },
+  "course_number": "8V81",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "624195234f665f12b94260b4"
+  },
+  "course_number": "6370",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "623fc70a48c0b7b7e6837875"
+  },
+  "course_number": "6342",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "623fedcd35f5a269783ff57f"
+  },
+  "course_number": "4345",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "623ff3cb35f5a269783ff6a5"
+  },
+  "course_number": "4201",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623ff4ce35f5a269783ff6d9"
+  },
+  "course_number": "7V90",
+  "subject_prefix": "EECS"
+},{
+  "_id": {
+    "$oid": "623ff9e135f5a269783ff70d"
+  },
+  "course_number": "6341",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "624001c935f5a269783ff8bb"
+  },
+  "course_number": "6363",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624006ff35f5a269783ff95f"
+  },
+  "course_number": "3399",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624008ba35f5a269783ff9af"
+  },
+  "course_number": "3080",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "62400f9b35f5a269783ffa67"
+  },
+  "course_number": "2366",
+  "subject_prefix": "ISNS"
+},{
+  "_id": {
+    "$oid": "6240ec0fd374e3c585977a9a"
+  },
+  "course_number": "4314",
+  "subject_prefix": "PPOL"
+},{
+  "_id": {
+    "$oid": "62406abbddc4b627a73bffe0"
+  },
+  "course_number": "3343",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "6240941cddc4b627a73c0469"
+  },
+  "course_number": "4336",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "624053bfddc4b627a73bfe8c"
+  },
+  "course_number": "6324",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "62406c21ddc4b627a73c002e"
+  },
+  "course_number": "7V91",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "62409659ddc4b627a73c04ea"
+  },
+  "course_number": "5369",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "62409bfcddc4b627a73c05c3"
+  },
+  "course_number": "6370",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240a092ddc4b627a73c0618"
+  },
+  "course_number": "4380",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240a128ddc4b627a73c066d"
+  },
+  "course_number": "6334",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6240a128ddc4b627a73c066f"
+  },
+  "course_number": "6349",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6240a2f3ddc4b627a73c06c8"
+  },
+  "course_number": "4309",
+  "subject_prefix": "IPEC"
+},{
+  "_id": {
+    "$oid": "6240b70cddc4b627a73c08ea"
+  },
+  "course_number": "5303",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6240bc9cddc4b627a73c0995"
+  },
+  "course_number": "6326",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240bd30ddc4b627a73c09b4"
+  },
+  "course_number": "3340",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6240cf19ddc4b627a73c0cb0"
+  },
+  "course_number": "4328",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62418d944f665f12b9425f66"
+  },
+  "course_number": "8V90",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "623fa5155647dcaa6c0cafef"
+  },
+  "course_number": "6193",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623ffa9835f5a269783ff7a6"
+  },
+  "course_number": "7370",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624006ff35f5a269783ff95d"
+  },
+  "course_number": "3368",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240073f35f5a269783ff97b"
+  },
+  "course_number": "6381",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240074035f5a269783ff97f"
+  },
+  "course_number": "7306",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62407c2dddc4b627a73c023c"
+  },
+  "course_number": "4330",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62400b7035f5a269783ffa13"
+  },
+  "course_number": "6V81",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "6240141c35f5a269783ffaa2"
+  },
+  "course_number": "3338",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62409bfaddc4b627a73c05b8"
+  },
+  "course_number": "4345",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240149835f5a269783ffabe"
+  },
+  "course_number": "6380",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "62409bfcddc4b627a73c05c1"
+  },
+  "course_number": "6365",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240149935f5a269783ffac4"
+  },
+  "course_number": "7372",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240a0e0ddc4b627a73c0643"
+  },
+  "course_number": "3115",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "6240149a35f5a269783ffac6"
+  },
+  "course_number": "7383",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240a10bddc4b627a73c0661"
+  },
+  "course_number": "6385",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6240de64e7c58a91f6b64b8e"
+  },
+  "course_number": "7300",
+  "subject_prefix": "OB"
+},{
+  "_id": {
+    "$oid": "6240a1f2ddc4b627a73c0698"
+  },
+  "course_number": "3092",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "6240a8c7ddc4b627a73c0755"
+  },
+  "course_number": "2320",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240e167e7c58a91f6b64be1"
+  },
+  "course_number": "3312",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240b438ddc4b627a73c07d3"
+  },
+  "course_number": "2306",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6240e9b9d374e3c585977a05"
+  },
+  "course_number": "3357",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240bc9cddc4b627a73c0999"
+  },
+  "course_number": "6334",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240c426ddc4b627a73c0ae1"
+  },
+  "course_number": "5323",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6240c7ebddc4b627a73c0b2b"
+  },
+  "course_number": "4116",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240c7eeddc4b627a73c0b3a"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62417c764f665f12b9425e01"
+  },
+  "course_number": "4090",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "623fb41f48c0b7b7e6837614"
+  },
+  "course_number": "4314",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fb42348c0b7b7e6837624"
+  },
+  "course_number": "4357",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fb42d48c0b7b7e6837650"
+  },
+  "course_number": "6381",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fbf9648c0b7b7e6837747"
+  },
+  "course_number": "3385",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "623fc51348c0b7b7e6837838"
+  },
+  "course_number": "7340",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fd2bf48c0b7b7e6837a30"
+  },
+  "course_number": "3336",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "623fedcc35f5a269783ff573"
+  },
+  "course_number": "3336",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "623fedce35f5a269783ff581"
+  },
+  "course_number": "4348",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6240062c35f5a269783ff8f8"
+  },
+  "course_number": "6388",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624013d235f5a269783ffa80"
+  },
+  "course_number": "1311",
+  "subject_prefix": "LANG"
+},{
+  "_id": {
+    "$oid": "6240145b35f5a269783ffab3"
+  },
+  "course_number": "6300",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240149835f5a269783ffab9"
+  },
+  "course_number": "6325",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240149935f5a269783ffac0"
+  },
+  "course_number": "6381",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240d7d5e7c58a91f6b64ae3"
+  },
+  "course_number": "7V12",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240e0ece7c58a91f6b64bd6"
+  },
+  "course_number": "3311",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240e9bad374e3c585977a0b"
+  },
+  "course_number": "4332",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240ec90d374e3c585977aa8"
+  },
+  "course_number": "6361",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "62406e6fddc4b627a73c008d"
+  },
+  "course_number": "6390",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62406e6fddc4b627a73c008f"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62408a7addc4b627a73c036a"
+  },
+  "course_number": "3340",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "62409426ddc4b627a73c049c"
+  },
+  "course_number": "6353",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "6240a93eddc4b627a73c076f"
+  },
+  "course_number": "3320",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240aa5bddc4b627a73c0799"
+  },
+  "course_number": "6V08",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "6240bca7ddc4b627a73c09ac"
+  },
+  "course_number": "6372",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240bd33ddc4b627a73c09b6"
+  },
+  "course_number": "4315",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6240c3abddc4b627a73c0adf"
+  },
+  "course_number": "6383",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240d8ecddc4b627a73c0d9b"
+  },
+  "course_number": "6319",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240e66addc4b627a73c0f6c"
+  },
+  "course_number": "7345",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6240f6a8ddc4b627a73c1099"
+  },
+  "course_number": "2350",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "623fa5165647dcaa6c0caff3"
+  },
+  "course_number": "6291",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623fc4e748c0b7b7e68377fa"
+  },
+  "course_number": "4355",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fcb4348c0b7b7e6837915"
+  },
+  "course_number": "4201",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6240073e35f5a269783ff971"
+  },
+  "course_number": "6320",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240093735f5a269783ff9cb"
+  },
+  "course_number": "4395",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240d558e7c58a91f6b64a68"
+  },
+  "course_number": "6392",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240e9a7d374e3c5859779e2"
+  },
+  "course_number": "7305",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6240ed11d374e3c585977abb"
+  },
+  "course_number": "4328",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240868fddc4b627a73c031e"
+  },
+  "course_number": "6348",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "62408791ddc4b627a73c0329"
+  },
+  "course_number": "7V91",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "62409a12ddc4b627a73c056e"
+  },
+  "course_number": "7371",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "62409d10ddc4b627a73c05ee"
+  },
+  "course_number": "4307",
+  "subject_prefix": "HLTH"
+},{
+  "_id": {
+    "$oid": "6240c3aaddc4b627a73c0adb"
+  },
+  "course_number": "6348",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240c7eaddc4b627a73c0b23"
+  },
+  "course_number": "3330",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240c7edddc4b627a73c0b33"
+  },
+  "course_number": "4186",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240ca2dddc4b627a73c0bbe"
+  },
+  "course_number": "4336",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6240d8edddc4b627a73c0d9d"
+  },
+  "course_number": "6339",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240deb1ddc4b627a73c0e73"
+  },
+  "course_number": "4336",
+  "subject_prefix": "RMIS"
+},{
+  "_id": {
+    "$oid": "62418d934f665f12b9425f5e"
+  },
+  "course_number": "8V80",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "624190c04f665f12b942602b"
+  },
+  "course_number": "5300",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "623fa50e5647dcaa6c0cafcf"
+  },
+  "course_number": "4302",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623fa6a25647dcaa6c0cb02e"
+  },
+  "course_number": "6341",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "623fa7295647dcaa6c0cb06a"
+  },
+  "course_number": "6388",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623fb42a48c0b7b7e6837642"
+  },
+  "course_number": "6310",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fb57348c0b7b7e683767c"
+  },
+  "course_number": "4095",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "623fc4f048c0b7b7e6837823"
+  },
+  "course_number": "6378",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fc4f248c0b7b7e683782d"
+  },
+  "course_number": "6V40",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fc4f348c0b7b7e6837833"
+  },
+  "course_number": "7088",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fd2fd48c0b7b7e6837a3c"
+  },
+  "course_number": "4193",
+  "subject_prefix": "CLDP"
+},{
+  "_id": {
+    "$oid": "624006c035f5a269783ff955"
+  },
+  "course_number": "3314",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624009fd35f5a269783ff9f1"
+  },
+  "course_number": "3106",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "6240145835f5a269783ffaad"
+  },
+  "course_number": "4390",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240145b35f5a269783ffab5"
+  },
+  "course_number": "6320",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240149835f5a269783ffabc"
+  },
+  "course_number": "6350",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240d7cde7c58a91f6b64abc"
+  },
+  "course_number": "4395",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240e9b8d374e3c585977a03"
+  },
+  "course_number": "3338",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240e9bad374e3c585977a0f"
+  },
+  "course_number": "6355",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240eb8fd374e3c585977a88"
+  },
+  "course_number": "4386",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6240ed89d374e3c585977acd"
+  },
+  "course_number": "4377",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240ed94d374e3c585977ae6"
+  },
+  "course_number": "7350",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240f05ad374e3c585977b59"
+  },
+  "course_number": "6327",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6240fb37d979c2aaf0678904"
+  },
+  "course_number": "6340",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "6240ed93d374e3c585977ae4"
+  },
+  "course_number": "6361",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241052ce31fd3ca4feac7a2"
+  },
+  "course_number": "6334",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "6240f85dd979c2aaf0678876"
+  },
+  "course_number": "5327",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "6240fe13d979c2aaf06789af"
+  },
+  "course_number": "6V80",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "62410529e31fd3ca4feac796"
+  },
+  "course_number": "4310",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "6241052ae31fd3ca4feac798"
+  },
+  "course_number": "4389",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "623f710d3cef432c2b39da6c"
+  },
+  "course_number": "5314",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623f73423cef432c2b39dad0"
+  },
+  "course_number": "6311",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "623f7fc53cef432c2b39dc33"
+  },
+  "course_number": "4320",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623f80853cef432c2b39dc65"
+  },
+  "course_number": "6326",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fc11fdc181bf821c04307"
+  },
+  "course_number": "4300",
+  "subject_prefix": "BPS"
+},{
+  "_id": {
+    "$oid": "62402930e8aa6728ab1e3ce7"
+  },
+  "course_number": "3315",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62402938e8aa6728ab1e3d16"
+  },
+  "course_number": "7329",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62403b78e8aa6728ab1e3e91"
+  },
+  "course_number": "7315",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240ae534adab090a35fd60d"
+  },
+  "course_number": "4V96",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "623ed7c493143dc133cc6eaf"
+  },
+  "course_number": "3383",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "623eed2f93143dc133cc6ffe"
+  },
+  "course_number": "3341",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623ef52693143dc133cc7143"
+  },
+  "course_number": "4193",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "623efdf493143dc133cc71df"
+  },
+  "course_number": "7320",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623f00a793143dc133cc7257"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "623f00a793143dc133cc725c"
+  },
+  "course_number": "4355",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62406ea05ee50c3313e40fb3"
+  },
+  "course_number": "6331",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "624074b95ee50c3313e41071"
+  },
+  "course_number": "6317",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624081895ee50c3313e41230"
+  },
+  "course_number": "3363",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624081a45ee50c3313e4123c"
+  },
+  "course_number": "4380",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240913d5ee50c3313e4133b"
+  },
+  "course_number": "2311",
+  "subject_prefix": "KORE"
+},{
+  "_id": {
+    "$oid": "6240b25e5ee50c3313e4150b"
+  },
+  "course_number": "6384",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240c1475ee50c3313e41765"
+  },
+  "course_number": "6391",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240f4aab04b136f30707226"
+  },
+  "course_number": "6303",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "623f0bf6435446f4890bf4cf"
+  },
+  "course_number": "3340",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6240f89ed979c2aaf067887a"
+  },
+  "course_number": "2340",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6240f8c4d979c2aaf06788dd"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "6240fe2fd979c2aaf06789cf"
+  },
+  "course_number": "3V10",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241052ae31fd3ca4feac79a"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "6241052de31fd3ca4feac7a4"
+  },
+  "course_number": "6337",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "623f71103cef432c2b39da81"
+  },
+  "course_number": "6337",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623f80863cef432c2b39dc6b"
+  },
+  "course_number": "6378",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623f72053cef432c2b39daa3"
+  },
+  "course_number": "4305",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "623f81113cef432c2b39dc7e"
+  },
+  "course_number": "7220",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "623f81d13cef432c2b39dca1"
+  },
+  "course_number": "4299",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "623f7f463cef432c2b39dbee"
+  },
+  "course_number": "3331",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624001cfbf28b6d88d6c79ec"
+  },
+  "course_number": "6398",
+  "subject_prefix": "EEPE"
+},{
+  "_id": {
+    "$oid": "623f80063cef432c2b39dc41"
+  },
+  "course_number": "4370",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe101bf28b6d88d6c75f2"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6240090ae8aa6728ab1e386d"
+  },
+  "course_number": "6324",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624015b8e8aa6728ab1e3a99"
+  },
+  "course_number": "7355",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "623fe38dbf28b6d88d6c7654"
+  },
+  "course_number": "7325",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "62403bfee8aa6728ab1e3e97"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "623fedfabf28b6d88d6c7742"
+  },
+  "course_number": "2337",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "624095754adab090a35fd326"
+  },
+  "course_number": "4326",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62401216e8aa6728ab1e39fd"
+  },
+  "course_number": "6355",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "624246f522d0f47645915010"
+  },
+  "course_number": "4334",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624032c7e8aa6728ab1e3da0"
+  },
+  "course_number": "6357",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "624032c8e8aa6728ab1e3da8"
+  },
+  "course_number": "6V29",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "623ed70893143dc133cc6e7f"
+  },
+  "course_number": "2348",
+  "subject_prefix": "ARTS"
+},{
+  "_id": {
+    "$oid": "62404071e8aa6728ab1e3f60"
+  },
+  "course_number": "4V96",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "623eecb593143dc133cc6fed"
+  },
+  "course_number": "3220",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240807a5ee50c3313e411cb"
+  },
+  "course_number": "7324",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6240a0574adab090a35fd40c"
+  },
+  "course_number": "4343",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240ac204adab090a35fd5b6"
+  },
+  "course_number": "3344",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "624085e15ee50c3313e412cf"
+  },
+  "course_number": "6390",
+  "subject_prefix": "HUMA"
+},{
+  "_id": {
+    "$oid": "624092215ee50c3313e41383"
+  },
+  "course_number": "6331",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6242497f22d0f4764591508f"
+  },
+  "course_number": "5330",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6242755422d0f476459154f9"
+  },
+  "course_number": "6335",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "624092225ee50c3313e41385"
+  },
+  "course_number": "6332",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240a9ce5ee50c3313e413c3"
+  },
+  "course_number": "3361",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "62427d8522d0f47645915592"
+  },
+  "course_number": "6335",
+  "subject_prefix": "SOC"
+},{
+  "_id": {
+    "$oid": "623ed29c93143dc133cc6de6"
+  },
+  "course_number": "6392",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "6240b0c65ee50c3313e4149e"
+  },
+  "course_number": "6393",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240b52e5ee50c3313e4156e"
+  },
+  "course_number": "3342",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "623ed2a593143dc133cc6df9"
+  },
+  "course_number": "6345",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "6241068ab04b136f3070748a"
+  },
+  "course_number": "4475",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "623ee2b793143dc133cc6f4d"
+  },
+  "course_number": "1300",
+  "subject_prefix": "BCOM"
+},{
+  "_id": {
+    "$oid": "623eec11435446f4890bf1aa"
+  },
+  "course_number": "1310",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "623ef56393143dc133cc7147"
+  },
+  "course_number": "4320",
+  "subject_prefix": "CGS"
+},{
+  "_id": {
+    "$oid": "624074465ee50c3313e41064"
+  },
+  "course_number": "4317",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624080775ee50c3313e411af"
+  },
+  "course_number": "6342",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624081855ee50c3313e41210"
+  },
+  "course_number": "2360",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624089685ee50c3313e4130e"
+  },
+  "course_number": "4310",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "624091c65ee50c3313e41345"
+  },
+  "course_number": "2322",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240921b5ee50c3313e41381"
+  },
+  "course_number": "6326",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240b8325ee50c3313e415da"
+  },
+  "course_number": "4361",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6240f81bb04b136f307072b5"
+  },
+  "course_number": "4320",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "623ef953435446f4890bf2b3"
+  },
+  "course_number": "6V70",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623f0bf6435446f4890bf4cd"
+  },
+  "course_number": "3321",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "623f80873cef432c2b39dc6d"
+  },
+  "course_number": "6385",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fc0ffdc181bf821c042b4"
+  },
+  "course_number": "3310",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fe100bf28b6d88d6c75ee"
+  },
+  "course_number": "8V91",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "623ffa41bf28b6d88d6c78c3"
+  },
+  "course_number": "7304",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "623ffa5ebf28b6d88d6c78ca"
+  },
+  "course_number": "2361",
+  "subject_prefix": "ECS"
+},{
+  "_id": {
+    "$oid": "62400c5ae8aa6728ab1e393b"
+  },
+  "course_number": "4396",
+  "subject_prefix": "GEOG"
+},{
+  "_id": {
+    "$oid": "6240166de8aa6728ab1e3a9e"
+  },
+  "course_number": "6301",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624031ece8aa6728ab1e3d54"
+  },
+  "course_number": "3340",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "624032c2e8aa6728ab1e3d83"
+  },
+  "course_number": "4V96",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "624095754adab090a35fd324"
+  },
+  "course_number": "4321",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "624253fd22d0f476459151a3"
+  },
+  "course_number": "3311",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "623ef46a93143dc133cc7128"
+  },
+  "course_number": "6331",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624073485ee50c3313e40ff4"
+  },
+  "course_number": "3330",
+  "subject_prefix": "ENGY"
+},{
+  "_id": {
+    "$oid": "62407b9f5ee50c3313e41174"
+  },
+  "course_number": "6321",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "6240913c5ee50c3313e41336"
+  },
+  "course_number": "1311",
+  "subject_prefix": "KORE"
+},{
+  "_id": {
+    "$oid": "6240bebe5ee50c3313e416f7"
+  },
+  "course_number": "7318",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240c1445ee50c3313e4174f"
+  },
+  "course_number": "1306",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240c1465ee50c3313e41762"
+  },
+  "course_number": "6390",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240fa04b04b136f307072ff"
+  },
+  "course_number": "3351",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "623edbab31c84563cbebc8bc"
+  },
+  "course_number": "3100",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "623eeb5b435446f4890bf19e"
+  },
+  "course_number": "8V80",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "623ef951435446f4890bf2a1"
+  },
+  "course_number": "6315",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6240efcfd374e3c585977b30"
+  },
+  "course_number": "4193",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "6240ed91d374e3c585977adc"
+  },
+  "course_number": "6302",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241052be31fd3ca4feac79c"
+  },
+  "course_number": "6300",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "623fc0ffdc181bf821c042b8"
+  },
+  "course_number": "3318",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "623fe101bf28b6d88d6c75f0"
+  },
+  "course_number": "8V98",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "623ff2fcbf28b6d88d6c785e"
+  },
+  "course_number": "1305",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624008eee8aa6728ab1e3824"
+  },
+  "course_number": "4300",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "62400a60e8aa6728ab1e38d5"
+  },
+  "course_number": "4305",
+  "subject_prefix": "FIN"
+},{
+  "_id": {
+    "$oid": "62400e1ce8aa6728ab1e3978"
+  },
+  "course_number": "6396",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6240166ee8aa6728ab1e3aa4"
+  },
+  "course_number": "6329",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "624019a1e8aa6728ab1e3af7"
+  },
+  "course_number": "2188",
+  "subject_prefix": "ISAH"
+},{
+  "_id": {
+    "$oid": "6240940a4adab090a35fd2ed"
+  },
+  "course_number": "4390",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "62409fdf4adab090a35fd401"
+  },
+  "course_number": "4303",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240ad184adab090a35fd5d8"
+  },
+  "course_number": "3350",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6240af8b4adab090a35fd625"
+  },
+  "course_number": "4354",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6242650722d0f47645915355"
+  },
+  "course_number": "3379",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623ed68993143dc133cc6e72"
+  },
+  "course_number": "6310",
+  "subject_prefix": "ARHM"
+},{
+  "_id": {
+    "$oid": "623efef093143dc133cc720b"
+  },
+  "course_number": "3353",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "623effec93143dc133cc723a"
+  },
+  "course_number": "6314",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "623f00a793143dc133cc7259"
+  },
+  "course_number": "3355",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "62406c4a5ee50c3313e40f62"
+  },
+  "course_number": "4202",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62407bac5ee50c3313e41178"
+  },
+  "course_number": "6363",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "624081b45ee50c3313e41246"
+  },
+  "course_number": "6342",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624083d95ee50c3313e4128b"
+  },
+  "course_number": "4395",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240b8345ee50c3313e415ec"
+  },
+  "course_number": "4382",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6240bdbb5ee50c3313e4166b"
+  },
+  "course_number": "4337",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240bf615ee50c3313e41704"
+  },
+  "course_number": "3314",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6240f9c6b04b136f307072f3"
+  },
+  "course_number": "1325",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6240ff3bb04b136f30707372"
+  },
+  "course_number": "3302",
+  "subject_prefix": "RHET"
+},{
+  "_id": {
+    "$oid": "624101fab04b136f307073e8"
+  },
+  "course_number": "5354",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "623f0db0435446f4890bf52a"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "623f716223cb74ff35739334"
+  },
+  "course_number": "6332",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6241052be31fd3ca4feac79e"
+  },
+  "course_number": "6303",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "6240fb58d979c2aaf0678934"
+  },
+  "course_number": "4193",
+  "subject_prefix": "SPAU"
+},{
+  "_id": {
+    "$oid": "6240fe2cd979c2aaf06789c1"
+  },
+  "course_number": "2311",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "623f7f4d3cef432c2b39dc0b"
+  },
+  "course_number": "3355",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623fe38bbf28b6d88d6c764d"
+  },
+  "course_number": "7222",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "623ff300bf28b6d88d6c7866"
+  },
+  "course_number": "2331",
+  "subject_prefix": "DANC"
+},{
+  "_id": {
+    "$oid": "624015b7e8aa6728ab1e3a97"
+  },
+  "course_number": "6394",
+  "subject_prefix": "HUAS"
+},{
+  "_id": {
+    "$oid": "6240ad414adab090a35fd5df"
+  },
+  "course_number": "4301",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "62427ba822d0f47645915568"
+  },
+  "course_number": "5330",
+  "subject_prefix": "SCI"
+},{
+  "_id": {
+    "$oid": "623ed2a493143dc133cc6df3"
+  },
+  "course_number": "6323",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "6240698d5ee50c3313e40f19"
+  },
+  "course_number": "4V90",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62407a595ee50c3313e4113f"
+  },
+  "course_number": "2321",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624080785ee50c3313e411bb"
+  },
+  "course_number": "6375",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624084105ee50c3313e412af"
+  },
+  "course_number": "6393",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240913d5ee50c3313e41339"
+  },
+  "course_number": "1312",
+  "subject_prefix": "KORE"
+},{
+  "_id": {
+    "$oid": "624091c85ee50c3313e41357"
+  },
+  "course_number": "2V71",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "624091ea5ee50c3313e41379"
+  },
+  "course_number": "6304",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240b2555ee50c3313e414e7"
+  },
+  "course_number": "4395",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240f588b04b136f30707247"
+  },
+  "course_number": "4306",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240f9dcb04b136f307072fb"
+  },
+  "course_number": "2314",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "62410b8ab04b136f30707530"
+  },
+  "course_number": "3112",
+  "subject_prefix": "UNIV"
+},{
+  "_id": {
+    "$oid": "623f80843cef432c2b39dc61"
+  },
+  "course_number": "6316",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "623ff167bf28b6d88d6c77c9"
+  },
+  "course_number": "4371",
+  "subject_prefix": "CS"
+},{
+  "_id": {
+    "$oid": "623ffa3ebf28b6d88d6c78b3"
+  },
+  "course_number": "4385",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "62401116e8aa6728ab1e39c2"
+  },
+  "course_number": "5314",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "6240186ae8aa6728ab1e3ae4"
+  },
+  "course_number": "8V99",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624032c6e8aa6728ab1e3d9e"
+  },
+  "course_number": "6356",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "62403a7fe8aa6728ab1e3e54"
+  },
+  "course_number": "4335",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "62403c3ce8aa6728ab1e3eb4"
+  },
+  "course_number": "6380",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "62403db6e8aa6728ab1e3ed1"
+  },
+  "course_number": "2321",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62403e31e8aa6728ab1e3ee1"
+  },
+  "course_number": "3130",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240942e4adab090a35fd2f0"
+  },
+  "course_number": "4396",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "624278e822d0f4764591553e"
+  },
+  "course_number": "3370",
+  "subject_prefix": "PSY"
+},{
+  "_id": {
+    "$oid": "623ed2a693143dc133cc6e03"
+  },
+  "course_number": "6375",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "623ed4d493143dc133cc6e44"
+  },
+  "course_number": "3318",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "624080765ee50c3313e411ab"
+  },
+  "course_number": "6323",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "624081895ee50c3313e41234"
+  },
+  "course_number": "3395",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624092225ee50c3313e41387"
+  },
+  "course_number": "6382",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240f4b6b04b136f3070722c"
+  },
+  "course_number": "6315",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6240f600b04b136f30707266"
+  },
+  "course_number": "6303",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240f9e0b04b136f307072fd"
+  },
+  "course_number": "3332",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6241027db04b136f30707409"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "SMED"
+},{
+  "_id": {
+    "$oid": "6240fb7dd979c2aaf0678972"
+  },
+  "course_number": "7334",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "623f73423cef432c2b39dad2"
+  },
+  "course_number": "6316",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "623f81493cef432c2b39dc83"
+  },
+  "course_number": "7282",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "623fd4a5bf28b6d88d6c7504"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623fe607bf28b6d88d6c76c6"
+  },
+  "course_number": "7307",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "624032cae8aa6728ab1e3db2"
+  },
+  "course_number": "7393",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "624095764adab090a35fd328"
+  },
+  "course_number": "4331",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62409e074adab090a35fd3d7"
+  },
+  "course_number": "5391",
+  "subject_prefix": "PHYS"
+},{
+  "_id": {
+    "$oid": "6240b7974adab090a35fd711"
+  },
+  "course_number": "3353",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6242674f22d0f47645915372"
+  },
+  "course_number": "8303",
+  "subject_prefix": "HUHI"
+},{
+  "_id": {
+    "$oid": "6242785522d0f4764591552e"
+  },
+  "course_number": "3323",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "623ef36493143dc133cc70b7"
+  },
+  "course_number": "3303",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "623ef45f93143dc133cc70e5"
+  },
+  "course_number": "4202",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "624072f35ee50c3313e40fd5"
+  },
+  "course_number": "6350",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "62407a5d5ee50c3313e4114c"
+  },
+  "course_number": "5309",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624081a75ee50c3313e4123e"
+  },
+  "course_number": "4390",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624081b15ee50c3313e41244"
+  },
+  "course_number": "6339",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240895e5ee50c3313e41308"
+  },
+  "course_number": "3334",
+  "subject_prefix": "ISIS"
+},{
+  "_id": {
+    "$oid": "624091ed5ee50c3313e4137b"
+  },
+  "course_number": "6315",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240a9c85ee50c3313e413bf"
+  },
+  "course_number": "3330",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "6240b0c55ee50c3313e41499"
+  },
+  "course_number": "6385",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6240c1465ee50c3313e41760"
+  },
+  "course_number": "6322",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6240f601b04b136f3070726b"
+  },
+  "course_number": "6315",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "623eec50435446f4890bf1b6"
+  },
+  "course_number": "3300",
+  "subject_prefix": "BA"
+},{
+  "_id": {
+    "$oid": "623f90843e27df3f067b1bb9"
+  },
+  "course_number": "4379",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623f8b0c3e27df3f067b1b50"
+  },
+  "course_number": "7382",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "623f716423cb74ff35739341"
+  },
+  "course_number": "7318",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "623f90873e27df3f067b1bd0"
+  },
+  "course_number": "6386",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fa18db4ba7ea2b8e965a9"
+  },
+  "course_number": "1312",
+  "subject_prefix": "LANG"
+},{
+  "_id": {
+    "$oid": "623fa1bfb4ba7ea2b8e965e6"
+  },
+  "course_number": "6373",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623ffb93da04e022fd824980"
+  },
+  "course_number": "6351",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242c67a86ab87d6f6d995fc"
+  },
+  "course_number": "6389",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6241f80074a2cbf30530503b"
+  },
+  "course_number": "5V00",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241fdf974a2cbf3053050b8"
+  },
+  "course_number": "3302",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6241fdfb74a2cbf3053050cc"
+  },
+  "course_number": "3332",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6241ffbb74a2cbf30530518c"
+  },
+  "course_number": "6386",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "624243b874a2cbf305305956"
+  },
+  "course_number": "2340",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "624255d374a2cbf305305c22"
+  },
+  "course_number": "6332",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "624255d474a2cbf305305c26"
+  },
+  "course_number": "6388",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6242b19f74a2cbf305306063"
+  },
+  "course_number": "6324",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6242b19f74a2cbf305306066"
+  },
+  "course_number": "6325",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6242b9d774a2cbf30530617a"
+  },
+  "course_number": "6371",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6242bcc974a2cbf305306224"
+  },
+  "course_number": "5320",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6242c89974a2cbf3053063ab"
+  },
+  "course_number": "3340",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6242ccec74a2cbf305306483"
+  },
+  "course_number": "6350",
+  "subject_prefix": "PA"
+},{
+  "_id": {
+    "$oid": "6242cd5574a2cbf3053064a6"
+  },
+  "course_number": "2304",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242cd5774a2cbf3053064bd"
+  },
+  "course_number": "6392",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242df5374a2cbf305306750"
+  },
+  "course_number": "3311",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "624040f2c32d55529d9bd444"
+  },
+  "course_number": "4339",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624064e6c32d55529d9bd78d"
+  },
+  "course_number": "6V49",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "6240910fc32d55529d9bdbdb"
+  },
+  "course_number": "7344",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "624098ecc32d55529d9bdce9"
+  },
+  "course_number": "5341",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6240a984c32d55529d9bdf17"
+  },
+  "course_number": "4371",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "6240acf0c32d55529d9bdf7b"
+  },
+  "course_number": "6371",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240c005c32d55529d9be192"
+  },
+  "course_number": "6348",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240c026c32d55529d9be1a6"
+  },
+  "course_number": "7393",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240c652c32d55529d9be28b"
+  },
+  "course_number": "4395",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240c6e0c32d55529d9be2b9"
+  },
+  "course_number": "3304",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6240e075c32d55529d9be638"
+  },
+  "course_number": "4333",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6240f211c32d55529d9be84d"
+  },
+  "course_number": "6377",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "623f8b0d3e27df3f067b1b52"
+  },
+  "course_number": "8V88",
+  "subject_prefix": "HCS"
+},{
+  "_id": {
+    "$oid": "623f90813e27df3f067b1ba2"
+  },
+  "course_number": "3306",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fa1bdb4ba7ea2b8e965da"
+  },
+  "course_number": "6310",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623fa1bfb4ba7ea2b8e965e9"
+  },
+  "course_number": "6378",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623fe55fda04e022fd82465c"
+  },
+  "course_number": "7393",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "623fe90cda04e022fd8246eb"
+  },
+  "course_number": "6396",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "623ffe88da04e022fd824a23"
+  },
+  "course_number": "4312",
+  "subject_prefix": "PPOL"
+},{
+  "_id": {
+    "$oid": "6241da5774a2cbf305304cf9"
+  },
+  "course_number": "3312",
+  "subject_prefix": "ACCT"
+},{
+  "_id": {
+    "$oid": "6241ffb874a2cbf305305183"
+  },
+  "course_number": "6373",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "6241ffba74a2cbf30530518a"
+  },
+  "course_number": "6385",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62420e1674a2cbf30530542d"
+  },
+  "course_number": "3321",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "62424b0174a2cbf305305a56"
+  },
+  "course_number": "3305",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62424b0474a2cbf305305a7a"
+  },
+  "course_number": "6342",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "624252c174a2cbf305305bb0"
+  },
+  "course_number": "4356",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624255d374a2cbf305305c1b"
+  },
+  "course_number": "6319",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6242bd8974a2cbf30530623e"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "MTHE"
+},{
+  "_id": {
+    "$oid": "6242df5674a2cbf305306753"
+  },
+  "course_number": "3312",
+  "subject_prefix": "SPAN"
+},{
+  "_id": {
+    "$oid": "6240400fc32d55529d9bd3d1"
+  },
+  "course_number": "2360",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240400fc32d55529d9bd3d3"
+  },
+  "course_number": "2375",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240401fc32d55529d9bd429"
+  },
+  "course_number": "4311",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62406a7ac32d55529d9bd879"
+  },
+  "course_number": "7307",
+  "subject_prefix": "CRIM"
+},{
+  "_id": {
+    "$oid": "62409100c32d55529d9bdbd3"
+  },
+  "course_number": "6326",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "6240a006c32d55529d9bddc7"
+  },
+  "course_number": "3364",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240db27c32d55529d9be569"
+  },
+  "course_number": "6308",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6240ec3ec32d55529d9be7b6"
+  },
+  "course_number": "7330",
+  "subject_prefix": "STAT"
+},{
+  "_id": {
+    "$oid": "6240f1d1c32d55529d9be83d"
+  },
+  "course_number": "4390",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "623f750123cb74ff35739414"
+  },
+  "course_number": "4331",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "623f83c03e27df3f067b19d5"
+  },
+  "course_number": "6347",
+  "subject_prefix": "EPPS"
+},{
+  "_id": {
+    "$oid": "623f90853e27df3f067b1bbc"
+  },
+  "course_number": "4386",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fe669da04e022fd824679"
+  },
+  "course_number": "6368",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "62400fe4cdfb8589b6a74d4d"
+  },
+  "course_number": "2302",
+  "subject_prefix": "RHET"
+},{
+  "_id": {
+    "$oid": "6241fdf874a2cbf3053050b0"
+  },
+  "course_number": "3200",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6241ffba74a2cbf305305185"
+  },
+  "course_number": "6382",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "6241ffba74a2cbf305305187"
+  },
+  "course_number": "6383",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "6242047674a2cbf305305280"
+  },
+  "course_number": "6310",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6242096974a2cbf305305321"
+  },
+  "course_number": "2233",
+  "subject_prefix": "CHEM"
+},{
+  "_id": {
+    "$oid": "62422c8774a2cbf3053055a8"
+  },
+  "course_number": "4386",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6242302474a2cbf305305674"
+  },
+  "course_number": "4V95",
+  "subject_prefix": "ED"
+},{
+  "_id": {
+    "$oid": "62424fc574a2cbf305305afb"
+  },
+  "course_number": "3105",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "6242cd5674a2cbf3053064ad"
+  },
+  "course_number": "3322",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242e20974a2cbf3053067b5"
+  },
+  "course_number": "6V80",
+  "subject_prefix": "SYSE"
+},{
+  "_id": {
+    "$oid": "6240400ec32d55529d9bd3cd"
+  },
+  "course_number": "2350",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240401fc32d55529d9bd42d"
+  },
+  "course_number": "4313",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62406952c32d55529d9bd80e"
+  },
+  "course_number": "7310",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "6240790ec32d55529d9bd8ef"
+  },
+  "course_number": "7321",
+  "subject_prefix": "ECON"
+},{
+  "_id": {
+    "$oid": "6240978cc32d55529d9bdcab"
+  },
+  "course_number": "6V98",
+  "subject_prefix": "FTEC"
+},{
+  "_id": {
+    "$oid": "62409ba7c32d55529d9bdd40"
+  },
+  "course_number": "4360",
+  "subject_prefix": "GST"
+},{
+  "_id": {
+    "$oid": "6240a00ac32d55529d9bdde6"
+  },
+  "course_number": "6341",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240c007c32d55529d9be19e"
+  },
+  "course_number": "6383",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240cc47c32d55529d9be37b"
+  },
+  "course_number": "4381",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6240d17bc32d55529d9be43a"
+  },
+  "course_number": "6352",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "623f87153e27df3f067b1abd"
+  },
+  "course_number": "4391",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "623f90863e27df3f067b1bc4"
+  },
+  "course_number": "6302",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623f90873e27df3f067b1bca"
+  },
+  "course_number": "6335",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623f90883e27df3f067b1bd3"
+  },
+  "course_number": "7321",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623f9a2f3e27df3f067b1d0a"
+  },
+  "course_number": "4395",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "623fa1bdb4ba7ea2b8e965dc"
+  },
+  "course_number": "6312",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623fa1bfb4ba7ea2b8e965eb"
+  },
+  "course_number": "7300",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623fd6f581629fdd308a854c"
+  },
+  "course_number": "4475",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "62400057da04e022fd824a68"
+  },
+  "course_number": "6309",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6241db7d74a2cbf305304dc9"
+  },
+  "course_number": "6307",
+  "subject_prefix": "ACTS"
+},{
+  "_id": {
+    "$oid": "62420feb74a2cbf305305485"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "6242377474a2cbf305305782"
+  },
+  "course_number": "6375",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "6242502b74a2cbf305305b37"
+  },
+  "course_number": "4350",
+  "subject_prefix": "IMS"
+},{
+  "_id": {
+    "$oid": "624252c374a2cbf305305bbe"
+  },
+  "course_number": "4382",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624255d374a2cbf305305c19"
+  },
+  "course_number": "6309",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6242b19f74a2cbf305306068"
+  },
+  "course_number": "6346",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6242b19f74a2cbf30530606d"
+  },
+  "course_number": "7313",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6242b1a074a2cbf305306070"
+  },
+  "course_number": "7318",
+  "subject_prefix": "MATH"
+},{
+  "_id": {
+    "$oid": "6242b9db74a2cbf305306198"
+  },
+  "course_number": "6389",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6242d28274a2cbf3053065b6"
+  },
+  "course_number": "6333",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6242d67f74a2cbf305306649"
+  },
+  "course_number": "2317",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6242d68974a2cbf30530664f"
+  },
+  "course_number": "3366",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "623fa1d0b4ba7ea2b8e96604"
+  },
+  "course_number": "6V00",
+  "subject_prefix": "MAS"
+},{
+  "_id": {
+    "$oid": "6240657bc32d55529d9bd7a2"
+  },
+  "course_number": "4301",
+  "subject_prefix": "CHIN"
+},{
+  "_id": {
+    "$oid": "6240a008c32d55529d9bddd2"
+  },
+  "course_number": "4342",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fe549da04e022fd824641"
+  },
+  "course_number": "6327",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "623fe54bda04e022fd82464d"
+  },
+  "course_number": "6359",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240a00ac32d55529d9bdde8"
+  },
+  "course_number": "6386",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6242c37686ab87d6f6d9958f"
+  },
+  "course_number": "6349",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240a985c32d55529d9bdf21"
+  },
+  "course_number": "4395",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "6241f80274a2cbf30530504f"
+  },
+  "course_number": "6684",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6240acf0c32d55529d9bdf7d"
+  },
+  "course_number": "6372",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6242047774a2cbf305305285"
+  },
+  "course_number": "6375",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "6240acf0c32d55529d9bdf7f"
+  },
+  "course_number": "6393",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "624236cd74a2cbf305305733"
+  },
+  "course_number": "4205",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "6240c6f0c32d55529d9be2c1"
+  },
+  "course_number": "6322",
+  "subject_prefix": "MSEN"
+},{
+  "_id": {
+    "$oid": "6242375074a2cbf305305780"
+  },
+  "course_number": "6310",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "6240cb74c32d55529d9be319"
+  },
+  "course_number": "3387",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "62424b0474a2cbf305305a7f"
+  },
+  "course_number": "6382",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240cc47c32d55529d9be379"
+  },
+  "course_number": "4380",
+  "subject_prefix": "NSC"
+},{
+  "_id": {
+    "$oid": "6242b6be74a2cbf305306103"
+  },
+  "course_number": "6350",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6240d105c32d55529d9be406"
+  },
+  "course_number": "4345",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240d3bdc32d55529d9be4c5"
+  },
+  "course_number": "6331",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242b9db74a2cbf305306196"
+  },
+  "course_number": "6386",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6242bc3474a2cbf3053061f4"
+  },
+  "course_number": "4395",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "623f91573e27df3f067b1c0f"
+  },
+  "course_number": "4395",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240d3bdc32d55529d9be4c7"
+  },
+  "course_number": "6345",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242c1f774a2cbf305306281"
+  },
+  "course_number": "1313",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6240e06bc32d55529d9be632"
+  },
+  "course_number": "3331",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6240e072c32d55529d9be636"
+  },
+  "course_number": "3373",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "62406951c32d55529d9bd80c"
+  },
+  "course_number": "7307",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "62406b45c32d55529d9bd892"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "6240e078c32d55529d9be63a"
+  },
+  "course_number": "4390",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6240f1dbc32d55529d9be843"
+  },
+  "course_number": "6324",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "6240a405c32d55529d9bde36"
+  },
+  "course_number": "4395",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "6240dc88c32d55529d9be5a6"
+  },
+  "course_number": "6308",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240dc88c32d55529d9be5ac"
+  },
+  "course_number": "6328",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240eea7c32d55529d9be7fe"
+  },
+  "course_number": "6V70",
+  "subject_prefix": "SYSM"
+},{
+  "_id": {
+    "$oid": "62411e7e51d891df387c2ec7"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "623f9ab13e27df3f067b1d1f"
+  },
+  "course_number": "2350",
+  "subject_prefix": "JAPN"
+},{
+  "_id": {
+    "$oid": "623fe54ada04e022fd824647"
+  },
+  "course_number": "6339",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "623feb05da04e022fd82472c"
+  },
+  "course_number": "4395",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "623ff350da04e022fd824862"
+  },
+  "course_number": "4395",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "62400021da04e022fd824a4a"
+  },
+  "course_number": "4326",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62400057da04e022fd824a66"
+  },
+  "course_number": "6306",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "62401c48cdfb8589b6a74ed5"
+  },
+  "course_number": "3361",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6242a89186ab87d6f6d9933d"
+  },
+  "course_number": "3354",
+  "subject_prefix": "CRWT"
+},{
+  "_id": {
+    "$oid": "6241daaa74a2cbf305304d7e"
+  },
+  "course_number": "6307",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "6241dade74a2cbf305304dad"
+  },
+  "course_number": "7351",
+  "subject_prefix": "ACN"
+},{
+  "_id": {
+    "$oid": "6241f7fc74a2cbf305305015"
+  },
+  "course_number": "4330",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62424fc574a2cbf305305af7"
+  },
+  "course_number": "3103",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "62424fc574a2cbf305305afe"
+  },
+  "course_number": "3107",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "6242b6b774a2cbf3053060c6"
+  },
+  "course_number": "3381",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "6242bc3774a2cbf305306210"
+  },
+  "course_number": "6373",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6242c1fb74a2cbf3053062a0"
+  },
+  "course_number": "2330",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6242c1fc74a2cbf3053062ae"
+  },
+  "course_number": "3131",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6242d67974a2cbf305306645"
+  },
+  "course_number": "1302",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6242d68274a2cbf30530664b"
+  },
+  "course_number": "2318",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "6242dac474a2cbf305306693"
+  },
+  "course_number": "3303",
+  "subject_prefix": "RHET"
+},{
+  "_id": {
+    "$oid": "6242e74c74a2cbf305306817"
+  },
+  "course_number": "2373",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "62404d86c32d55529d9bd5d3"
+  },
+  "course_number": "4308",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "62406953c32d55529d9bd817"
+  },
+  "course_number": "7387",
+  "subject_prefix": "COMD"
+},{
+  "_id": {
+    "$oid": "62408883c32d55529d9bdac6"
+  },
+  "course_number": "4204",
+  "subject_prefix": "EE"
+},{
+  "_id": {
+    "$oid": "62408a90c32d55529d9bdb2f"
+  },
+  "course_number": "6322",
+  "subject_prefix": "EEMF"
+},{
+  "_id": {
+    "$oid": "624098e9c32d55529d9bdce5"
+  },
+  "course_number": "5308",
+  "subject_prefix": "GEOS"
+},{
+  "_id": {
+    "$oid": "6240a007c32d55529d9bddcb"
+  },
+  "course_number": "3391",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240c656c32d55529d9be2a9"
+  },
+  "course_number": "6345",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240cdb7c32d55529d9be3ba"
+  },
+  "course_number": "4395",
+  "subject_prefix": "OBHR"
+},{
+  "_id": {
+    "$oid": "6240db2ec32d55529d9be56e"
+  },
+  "course_number": "6328",
+  "subject_prefix": "PPPE"
+},{
+  "_id": {
+    "$oid": "6240dc89c32d55529d9be5b0"
+  },
+  "course_number": "6342",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "623f90823e27df3f067b1ba9"
+  },
+  "course_number": "3346",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623f90873e27df3f067b1bcc"
+  },
+  "course_number": "6341",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "623fa190b4ba7ea2b8e965ab"
+  },
+  "course_number": "3301",
+  "subject_prefix": "LATS"
+},{
+  "_id": {
+    "$oid": "623fa1bfb4ba7ea2b8e965e4"
+  },
+  "course_number": "6360",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623ff6fbda04e022fd8248ba"
+  },
+  "course_number": "4395",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "623ff716da04e022fd824918"
+  },
+  "course_number": "7343",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240031ada04e022fd824ae5"
+  },
+  "course_number": "7382",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "6241ecb374a2cbf305304e98"
+  },
+  "course_number": "7352",
+  "subject_prefix": "AUD"
+},{
+  "_id": {
+    "$oid": "6241fdff74a2cbf305305100"
+  },
+  "course_number": "6367",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6241ffb874a2cbf305305181"
+  },
+  "course_number": "6368",
+  "subject_prefix": "BUAN"
+},{
+  "_id": {
+    "$oid": "62424b0174a2cbf305305a60"
+  },
+  "course_number": "3341",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62424f8574a2cbf305305acb"
+  },
+  "course_number": "4395",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "62424fc674a2cbf305305b03"
+  },
+  "course_number": "3109",
+  "subject_prefix": "HONS"
+},{
+  "_id": {
+    "$oid": "624252bf74a2cbf305305ba0"
+  },
+  "course_number": "4344",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624252c374a2cbf305305bc0"
+  },
+  "course_number": "4395",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "6242b9d874a2cbf30530617e"
+  },
+  "course_number": "6374",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6242c1fe74a2cbf3053062bc"
+  },
+  "course_number": "3327",
+  "subject_prefix": "MUSI"
+},{
+  "_id": {
+    "$oid": "6242cd5574a2cbf3053064a2"
+  },
+  "course_number": "1307",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "6242e74c74a2cbf305306820"
+  },
+  "course_number": "4342",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6242e79874a2cbf30530683b"
+  },
+  "course_number": "6336",
+  "subject_prefix": "VPAS"
+},{
+  "_id": {
+    "$oid": "624029ca3b93c05ddb026c97"
+  },
+  "course_number": "4360",
+  "subject_prefix": "AMS"
+},{
+  "_id": {
+    "$oid": "624040f1c32d55529d9bd43c"
+  },
+  "course_number": "4327",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624040f1c32d55529d9bd43e"
+  },
+  "course_number": "4332",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624041a5c32d55529d9bd485"
+  },
+  "course_number": "8306",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "62405130c32d55529d9bd688"
+  },
+  "course_number": "6338",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "624069dec32d55529d9bd840"
+  },
+  "course_number": "3340",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "624069dfc32d55529d9bd844"
+  },
+  "course_number": "4305",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6240898bc32d55529d9bdb24"
+  },
+  "course_number": "6309",
+  "subject_prefix": "EEDG"
+},{
+  "_id": {
+    "$oid": "6240aceec32d55529d9bdf6f"
+  },
+  "course_number": "6306",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240e871c32d55529d9be714"
+  },
+  "course_number": "8V02",
+  "subject_prefix": "SE"
+},{
+  "_id": {
+    "$oid": "62411bdc51d891df387c2ebd"
+  },
+  "course_number": "3350",
+  "subject_prefix": "COMM"
+},{
+  "_id": {
+    "$oid": "6241389e51d891df387c3115"
+  },
+  "course_number": "6V95",
+  "subject_prefix": "MECH"
+},{
+  "_id": {
+    "$oid": "623f81e723cb74ff357394b7"
+  },
+  "course_number": "3321",
+  "subject_prefix": "ENTP"
+},{
+  "_id": {
+    "$oid": "623f8b913e27df3f067b1b60"
+  },
+  "course_number": "7382",
+  "subject_prefix": "HDCD"
+},{
+  "_id": {
+    "$oid": "623f9a2e3e27df3f067b1d01"
+  },
+  "course_number": "4362",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "623fa1c0b4ba7ea2b8e965ed"
+  },
+  "course_number": "7322",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "623fe5ebda04e022fd82465e"
+  },
+  "course_number": "3360",
+  "subject_prefix": "MECO"
+},{
+  "_id": {
+    "$oid": "623ffb92da04e022fd82497c"
+  },
+  "course_number": "4333",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "623ffb92da04e022fd82497e"
+  },
+  "course_number": "6325",
+  "subject_prefix": "PHIL"
+},{
+  "_id": {
+    "$oid": "62400057da04e022fd824a6c"
+  },
+  "course_number": "6343",
+  "subject_prefix": "PSCI"
+},{
+  "_id": {
+    "$oid": "6240031ada04e022fd824ae3"
+  },
+  "course_number": "6352",
+  "subject_prefix": "PSYC"
+},{
+  "_id": {
+    "$oid": "62401c49cdfb8589b6a74edb"
+  },
+  "course_number": "4V71",
+  "subject_prefix": "THEA"
+},{
+  "_id": {
+    "$oid": "6241f7f174a2cbf305304fbd"
+  },
+  "course_number": "3203",
+  "subject_prefix": "BIOL"
+},{
+  "_id": {
+    "$oid": "6241fdf774a2cbf3053050a4"
+  },
+  "course_number": "1300",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6241fdfa74a2cbf3053050c7"
+  },
+  "course_number": "3331",
+  "subject_prefix": "BMEN"
+},{
+  "_id": {
+    "$oid": "6242046e74a2cbf30530523c"
+  },
+  "course_number": "4205",
+  "subject_prefix": "CE"
+},{
+  "_id": {
+    "$oid": "62423cb174a2cbf3053057b6"
+  },
+  "course_number": "7V85",
+  "subject_prefix": "EESC"
+},{
+  "_id": {
+    "$oid": "6242455a74a2cbf30530599b"
+  },
+  "course_number": "6363",
+  "subject_prefix": "GISC"
+},{
+  "_id": {
+    "$oid": "62424b0274a2cbf305305a66"
+  },
+  "course_number": "3394",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62424b0374a2cbf305305a6f"
+  },
+  "course_number": "4381",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "62424f8974a2cbf305305af1"
+  },
+  "course_number": "6374",
+  "subject_prefix": "HMGT"
+},{
+  "_id": {
+    "$oid": "624252c274a2cbf305305bb6"
+  },
+  "course_number": "4361",
+  "subject_prefix": "ITSS"
+},{
+  "_id": {
+    "$oid": "624255d374a2cbf305305c1f"
+  },
+  "course_number": "6326",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "624255d474a2cbf305305c28"
+  },
+  "course_number": "7321",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6242b9d774a2cbf305306176"
+  },
+  "course_number": "6368",
+  "subject_prefix": "MIS"
+},{
+  "_id": {
+    "$oid": "6242c90e74a2cbf3053063cc"
+  },
+  "course_number": "4362",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6242c91274a2cbf3053063cf"
+  },
+  "course_number": "4395",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "624028f33b93c05ddb026c7a"
+  },
+  "course_number": "6V99",
+  "subject_prefix": "AHST"
+},{
+  "_id": {
+    "$oid": "6240400ac32d55529d9bd3ba"
+  },
+  "course_number": "2325",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240400bc32d55529d9bd3c2"
+  },
+  "course_number": "2340",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240412ac32d55529d9bd457"
+  },
+  "course_number": "4374",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "624041a4c32d55529d9bd483"
+  },
+  "course_number": "7390",
+  "subject_prefix": "ATCM"
+},{
+  "_id": {
+    "$oid": "6240a007c32d55529d9bddc9"
+  },
+  "course_number": "3380",
+  "subject_prefix": "HIST"
+},{
+  "_id": {
+    "$oid": "6240aceec32d55529d9bdf6b"
+  },
+  "course_number": "4V99",
+  "subject_prefix": "LIT"
+},{
+  "_id": {
+    "$oid": "6240c658c32d55529d9be2b5"
+  },
+  "course_number": "7317",
+  "subject_prefix": "MKT"
+},{
+  "_id": {
+    "$oid": "6240d106c32d55529d9be40d"
+  },
+  "course_number": "4395",
+  "subject_prefix": "OPRE"
+},{
+  "_id": {
+    "$oid": "6240e068c32d55529d9be62f"
+  },
+  "course_number": "2316",
+  "subject_prefix": "RELS"
+},{
+  "_id": {
+    "$oid": "62412f5b51d891df387c305c"
+  },
+  "course_number": "4V94",
+  "subject_prefix": "IMS"
+}]

--- a/scraper/scripts/BuildExamCourseAssociations.ts
+++ b/scraper/scripts/BuildExamCourseAssociations.ts
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { stringify } from 'querystring';
+
+const examReadFile = '../data/ExamsWithoutObjectIds.json';
+const examWriteFile = '../data/Exams.json';
+const courseFile = '../data/Courses.json';
+
+writeExamsToFile(buildExamCourseAssociations(examReadFile, courseFile), examWriteFile);
+
+function findCourseObjectId(courses: [any], prefix: string, number: string): string {
+  for (const course of courses) {
+    if (course.subject_prefix === prefix && course.course_number === number) {
+      return course._id;
+    }
+  }
+
+  // course not found
+  return null;
+}
+
+function buildExamCourseAssociations(examReadFile: string, courseFile: string) {
+  //var unknownCourseCount = 0;
+  const exams = JSON.parse(readFileSync(examReadFile, 'utf8'));
+
+  const courses = JSON.parse(readFileSync(courseFile, 'utf8'));
+
+  // List of exams
+  for (let e = 0; e < exams.length; e++) {
+    const exam = exams[e];
+
+    // list of yields
+    for (let i = 0; i < exam.yields.length; i++) {
+      const choices = exam.yields[i].outcome;
+
+      // list of choices
+      for (let j = 0; j < choices.length; j++) {
+        const choice = choices[j];
+
+        // list of courses in choice
+        for (let k = 0; k < choice.length; k++) {
+          const course = choice[k];
+
+          // grab course prefix and number
+          if (
+            'prefix' in course &&
+            'number' in course &&
+            course.prefix !== null &&
+            course.number !== null
+          ) {
+            const courseId = findCourseObjectId(courses, course.prefix, course.number.toString());
+            if (courseId !== null) {
+              // Replace the Course prefix and number object with the associated ObjectId
+              exams[e].yields[i].outcome[j][k] = courseId;
+            }
+            /*else {
+                            console.log("COURSE NOT IN COURSES DATABASE");
+                            console.log(course.prefix + " " + course.number);
+                            unknownCourseCount++;
+                        }*/
+          }
+        }
+      }
+    }
+  }
+
+  //console.log("Number of Unknown Courses: " + unknownCourseCount);
+
+  return exams;
+}
+
+function writeExamsToFile(exams: [any], filename = './Exams.json') {
+  writeFileSync(filename, JSON.stringify(exams, null, '\t'), { flag: 'w' });
+}
+
+writeExamsToFile(buildExamCourseAssociations(examReadFile, courseFile), examWriteFile);


### PR DESCRIPTION
This is the resulting data from scrapping from the UT Dallas Exam sites for IP, AP, CLEP, and ALEKS, per #66.

This will need to be incorporated to the database deployments as seen fit.

This is mostly done by hand as I haven't had internet access to develop and debug the scraper. I hope to have that finished before 3/28/2022, but depending on our priorities may have to push that further down the road.