### PR TITLE
Add `DegreeSubtype`s

### DIFF
--- a/docs/schemas/degree.md
+++ b/docs/schemas/degree.md
@@ -5,7 +5,7 @@ A `Degree` represents either a major, minor, or concentration received from The 
 
 ## Object Representation
 ```ts
-DegreeSubtype = "major" | "minor" | "concentration" | "prescribed double major"
+DegreeSubtype = "major" | "minor" | "concentration" | "prescribed double major" | "certificate" | "track"
 
 Degree = {
     "_id": ObjectId,


### PR DESCRIPTION
Added `certificate` and `track` degree subtypes as options. This is since there are quite a few certificates offered such as the Certificate in Information Assurance. In addition, the Bachelors of Arts in Education degree has several tracks one can take to specialize in teaching a certain area. These new subtypes cover these cases I've spotted while working on the degrees scraper.