### PR TITLE
Add `catalog_uri` property

### DIFF
--- a/docs/schemas/degree.md
+++ b/docs/schemas/degree.md
@@ -15,6 +15,7 @@ Degree = {
     "year": string,
     "abbreviation": string,
     "minimum_credit_hours": number,
+    "catalog_uri": string,
     "requirements": CollectionRequirement,
 }
 ```
@@ -75,6 +76,14 @@ Degree = {
 > The minimum credit hours required for the degree, which can be found on the UTD catalog.
 >
 > **Example**: 124
+
+> `.catalog_uri`
+>
+> **Type**: string
+>
+> A link to the listing of the degree and its requirements in the UTD catalog.
+>
+> **Example**: https://catalog.utdallas.edu/2021/undergraduate/programs/ah/philosophy
 
 > `.requirements`
 >


### PR DESCRIPTION
I thought it might be useful to store the link to the degree in the catalog since we do that for professors already. I already have the links to each degree in the process of scraping so it takes no work to add this data in.