### PR TITLE
Move requisite properties from Course to Section schema

### DIFF
--- a/docs/schemas/course.md
+++ b/docs/schemas/course.md
@@ -17,8 +17,6 @@ Course = {
     "activity_type": string,
     "grading": string,
     "internal_course_number": string,
-    "prerequisites": CollectionRequirement,
-    "corequisites": CollectionRequirement,
     "lecture_contact_hours": string,
     "laboratory_contact_hours": string,
     "offering_frequency": string,
@@ -114,18 +112,6 @@ Course = {
 > The internal (university) number used to reference this course.
 >
 > **Example**: 008613
-
-> `.prerequisites`
->
-> **Type**: CollectionRequirement
->
-> A collection of prerequisites that must be met before a student may enroll in a section of this course.
-
-> `.corequisites`
->
-> **Type**: CollectionRequirement
->
-> A collection of all course requirements that must be met either before or while a student enrolls in a section of this course.
 
 > `.lecture_contact_hours`
 >

--- a/docs/schemas/section.md
+++ b/docs/schemas/section.md
@@ -9,7 +9,9 @@ Section = {
     "_id": ObjectId,
     "section_number": string,
     "course_reference": ObjectId,
-    "section_corequisites": CollectionRequirement,
+    "prerequisites": CollectionRequirement,
+    "corequisites": CollectionRequirement,
+    "co_or_pre_requisites": CollectionRequirement,
     "academic_session": AcademicSession,
     "professors": Array<ObjectId>,
     "teaching_assistants": Array<Assistant>,
@@ -48,11 +50,23 @@ Section = {
 > 
 > **Example**:
 
-> `.section_corequisites`
+> `.prerequisites`
+>
+> **Type**: CollectionRequirement
+>
+> A collection of requirements that must be met before a student may enroll in this section.
+
+> `.corequisites`
+>
+> **Type**: CollectionRequirement
+>
+> A collection of requirements that must be met while a student enrolls in this section.
+
+> `.co_or_pre_requisites`
 > 
 > **Type**: CollectionRequirement
 > 
-> A collection of all sections that must be taken alongside this section such as specific labs and exam sections.
+> A collection of requirements that must be met either before or while a student enrolls in this section.
 
 > `.academic_session`
 > 


### PR DESCRIPTION
This change makes the requisite system make more sense to me, and fits with the fact that not all sections under the same course have the same requisites, i.e. honors sections. This also removes the (imo unnecessary) distinction between course and section-specific requisites.

I have also added the `.co_or_pre_requisites` property, as coursebook actually does provide a distinction between prerequsites, corequisites, and co- *or* pre- requisites.