### PR TITLE
Update models and redirect some to combinedDB

### DIFF
--- a/api/models/course.ts
+++ b/api/models/course.ts
@@ -1,6 +1,7 @@
 import { Schema, connection } from 'mongoose';
 
 export interface Course {
+  _id: string;
   course_number: string;
   subject_prefix: string;
   title: string;
@@ -13,12 +14,16 @@ export interface Course {
   internal_course_number: string;
   prerequisites: object;
   corequisites: object;
+  co_or_pre_requisites: object;
+  sections: string[];
   lecture_contact_hours: string;
   laboratory_contact_hours: string;
+  offering_frequency: string;
   attributes: object;
 }
 
 export const CourseSchema = new Schema<Course>({
+  _id: { type: String, required: true },
   course_number: { type: String, required: true },
   subject_prefix: { type: String, required: true },
   title: { type: String, required: true },
@@ -31,10 +36,13 @@ export const CourseSchema = new Schema<Course>({
   internal_course_number: { type: String, required: true },
   prerequisites: { type: Object, required: true },
   corequisites: { type: Object, required: true },
+  co_or_pre_requisites: { type: Object, required: true },
+  sections: { type: [String], required: true },
   lecture_contact_hours: { type: String, required: true },
   laboratory_contact_hours: { type: String, required: true },
+  offering_frequency: { type: String, required: true },
   attributes: { type: Object, required: true },
 });
 
-const courseDB = connection.useDb('courseDB');
+const courseDB = connection.useDb('combinedDB');
 export const CourseModel = courseDB.model<Course>('course', CourseSchema);

--- a/api/models/exam.ts
+++ b/api/models/exam.ts
@@ -3,11 +3,13 @@ import { Schema, connection } from 'mongoose';
 type ExamType = 'AP' | 'ALEKS' | 'CLEP' | 'IB' | 'CS placement';
 
 export interface Exam {
+  _id: string;
   type: ExamType;
   yields: Record<number, Schema.Types.ObjectId>;
 }
 
 export const ExamSchema = new Schema<Exam>({
+  _id: { type: String, required: true },
   type: { type: String, required: true },
   yields: { type: Object, required: true },
 });

--- a/api/models/professor.ts
+++ b/api/models/professor.ts
@@ -2,6 +2,7 @@ import { Schema, connection } from 'mongoose';
 import { Location, Meeting } from './section'; // dependency will be resolved with section pull request
 
 export interface Professor {
+  _id: string;
   first_name: string;
   last_name: string;
   titles: Array<string>;
@@ -15,6 +16,7 @@ export interface Professor {
 }
 
 export const ProfessorSchema = new Schema<Professor>({
+  _id: { type: String, required: true },
   first_name: { type: String, required: true },
   last_name: { type: String, required: true },
   titles: { type: [String], required: true },
@@ -27,5 +29,5 @@ export const ProfessorSchema = new Schema<Professor>({
   sections: { type: [Schema.Types.ObjectId], required: true },
 });
 
-const professorDB = connection.useDb('professorDB');
+const professorDB = connection.useDb('combinedDB');
 export const ProfessorModel = professorDB.model<Professor>('professor', ProfessorSchema);

--- a/api/models/section.ts
+++ b/api/models/section.ts
@@ -32,6 +32,7 @@ export type Meeting = {
 };
 
 export interface Section {
+  _id: string;
   section_number: string;
   course_reference: Schema.Types.ObjectId;
   section_corequisites: object; // i was too lazy and did not code all the requirements, but it should still work with object
@@ -41,12 +42,14 @@ export interface Section {
   internal_class_number: string;
   instruction_mode: string;
   meetings: Array<Meeting>;
+  core_flags: Array<string>;
   syllabus_uri: string;
   grade_distribution: Array<number>;
   attributes: object;
 }
 
 export const SectionSchema = new Schema<Section>({
+  _id: { type: String, required: true },
   section_number: { type: String, required: true },
   course_reference: { type: Schema.Types.ObjectId, required: true },
   section_corequisites: { type: Object, required: true },
@@ -56,10 +59,11 @@ export const SectionSchema = new Schema<Section>({
   internal_class_number: { type: String, required: true },
   instruction_mode: { type: String, required: true },
   meetings: { type: [Object], required: true },
+  core_flags: { type: [String], required: true },
   syllabus_uri: { type: String, required: true },
   grade_distribution: { type: [Number], required: true },
   attributes: { type: Object, required: true },
 });
 
-const sectionDB = connection.useDb('sectionDB');
+const sectionDB = connection.useDb('combinedDB');
 export const SectionModel = sectionDB.model<Section>('section', SectionSchema);


### PR DESCRIPTION
Some of the models have been switched to use the combinedDB as aggregation only works when collections are within the same database.

Some of the models have been updated to have the _id string and some missing values.