### PR TITLE
Docs improvements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ NEBULA-API
     └───scripts
 ```
 
-# Building 
+# Building
 
 ## Standalone Executable
 
@@ -45,7 +45,7 @@ and
 
 By default, REGISTRY is set to `localhost:5000`. You can set this as a different environment variable if you want to upload the docker image to a different registry.
 
-# Testing 
+# Testing
 
 ## Linting
 
@@ -58,6 +58,7 @@ To run `staticcheck` refer to [this URL](https://staticcheck.io/docs/getting-sta
 ## Standalone
 
 To connect to your Mongo database, in /api/.env: set MONGODB_URI accordingly:
+
 ```
 MONGODB_URI=<insert_connection_string_here>
 ```

--- a/docs/schemas/academic_session.md
+++ b/docs/schemas/academic_session.md
@@ -1,9 +1,11 @@
 # Academic Session
+
 ## Overview
 
 An `AcademicSession` represents the time period in which courses takes place.
 
 ## Object Representation
+
 ```ts
 AcademicSession = {
     "name": string,
@@ -11,14 +13,16 @@ AcademicSession = {
     "end_date": string,
 }
 ```
+
 ## Properties
+
 > `.name`
 >
 > **Type**: string
 >
 > The name of the academic session in question.
 >
-> **Example**: Spring 2022
+> **Examples**: `22S`, `18F`, `23U`
 
 > `.start_date`
 >
@@ -26,7 +30,7 @@ AcademicSession = {
 >
 > The date of classes starting in the academic session.
 >
-> **Example**: January 18, 2022
+> **Example**: `2022-01-18T00:00:00-06:00`
 
 > `.end_date`
 >
@@ -34,4 +38,4 @@ AcademicSession = {
 >
 > The date of classes ending in the academic session.
 >
-> **Example**: May 5, 2022
+> **Example**: `2022-05-13T00:00:00-05:00`

--- a/docs/schemas/assistant.md
+++ b/docs/schemas/assistant.md
@@ -1,9 +1,11 @@
 # Assistant
+
 ## Overview
 
 An 'Assistant' represents a teaching assistant at UT Dallas.
 
 ## Object Representation
+
 ```ts
 Assistant = {
     "first_name": string,
@@ -14,6 +16,7 @@ Assistant = {
 ```
 
 ## Properties
+
 > **Type**: ObjectId
 >
 > The MongoDB database id for the `Assistant` object.
@@ -26,7 +29,7 @@ Assistant = {
 >
 > The first name of the assistant.
 >
-> **Example**: John
+> **Example**: `John`
 
 > `.last_name`
 >
@@ -34,7 +37,7 @@ Assistant = {
 >
 > The last name of the assistant.
 >
-> **Example**: Doe
+> **Example**: `Doe`
 
 > `.role`
 >
@@ -42,7 +45,7 @@ Assistant = {
 >
 > The role of the assistant.
 >
-> **Example**: "Teaching Assistant", "Guest/Visiting Lecturer"
+> **Example**: `Teaching Assistant`
 
 > `.email`
 >
@@ -50,4 +53,4 @@ Assistant = {
 >
 > The email address to contact the assistant.
 >
-> **Example**: xxx555555@utdallas.edu
+> **Example**: `xxx555555@utdallas.edu`

--- a/docs/schemas/course.md
+++ b/docs/schemas/course.md
@@ -1,9 +1,11 @@
 # Course
+
 ## Overview
 
 The `Course` object represents a course available at the University of Texas at Dallas. A `Course` should not be confused with a `Section` which is the actual instantiation of a `Course` with a professor and dedicated meeting times.
 
 ## Object Representation
+
 ```ts
 Course = {
     "_id": ObjectId,
@@ -27,8 +29,9 @@ Course = {
 ```
 
 ## Properties
+
 > `._id`
-> 
+>
 > **Type**: ObjectId
 >
 > The MongoDB database id for the `Course` object.
@@ -81,7 +84,7 @@ Course = {
 >
 > The number of credit hours awarded by successful completion of the course. Will be "V" if variable credit hours.
 >
-> **Example**: "4", "V"
+> **Examples**: "4", "V"
 
 > `.class_level`
 >

--- a/docs/schemas/credit.md
+++ b/docs/schemas/credit.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `Credit` object represents an amount of 'semester credit hours' given by The University of Texas at Dallas. A `Credit` should not be confused with a `Course` as semester credit hours serve only to fulfill credit hour requirements.
+The `Credit` object represents an amount of 'semester credit hours' given by The University of Texas at Dallas. A `Credit` should not be confused with a `Course` as semester credit hours serve only to fulfill credit hour requirements. This is currently used to identify exam elective credit.
 
 ## Object Representation
 
@@ -19,11 +19,11 @@ Credit = {
 >
 > **Type**: string
 >
-> The catergory of the credit hours.
+> The category of the credit hours.
 > If there is no category associated with the credit, the value is "general".
 > "free" is a valid category.
 >
-> **Example**: "Geosciences", "Business Computer Information Systems", "free"
+> **Examples**: `Geosciences`, `Business Computer Information Systems`, `free`
 
 > `.credit_hours`
 >

--- a/docs/schemas/degree.md
+++ b/docs/schemas/degree.md
@@ -1,9 +1,11 @@
 # Degree
+
 ## Overview
 
 A `Degree` represents either a major, minor, or concentration received from The University of Texas at Dallas.
 
 ## Object Representation
+
 ```ts
 DegreeSubtype = "major" | "minor" | "concentration" | "prescribed double major" | "certificate" | "track"
 
@@ -21,6 +23,7 @@ Degree = {
 ```
 
 ## Properties
+
 > `._id`
 >
 > **Type**: ObjectId
@@ -35,7 +38,7 @@ Degree = {
 >
 > The subtype of degree that this object represents.
 >
-> **Example**: Major
+> **Example**: `major`
 
 > `.school`
 >
@@ -43,7 +46,7 @@ Degree = {
 >
 > The school that the `degree` belongs to.
 >
-> **Example**: School of Natural Sciences and Mathematics
+> **Example**: `School of Natural Sciences and Mathematics`
 
 > `.name`
 >
@@ -51,15 +54,15 @@ Degree = {
 >
 > The full name of the degree.
 >
-> **Example**: Bachelor of Science in Computer Science
+> **Example**: `Bachelor of Science in Computer Science`
 
 > `.year`
-> 
+>
 > **Type**: string
 >
 > The academic year to which this degree corresponds to.
 >
-> **Example**: 2021-2022
+> **Example**: `2021-2022`
 
 > `.abbreviation`
 >
@@ -67,7 +70,7 @@ Degree = {
 >
 >The abbreviation of the degree.
 >
-> **Example**: B.S. in Computer Science
+> **Example**: `B.S. in Computer Science`
 
 > `.minimum_credit_hours`
 >
@@ -83,7 +86,7 @@ Degree = {
 >
 > A link to the listing of the degree and its requirements in the UTD catalog.
 >
-> **Example**: https://catalog.utdallas.edu/2021/undergraduate/programs/ah/philosophy
+> **Example**: `https://catalog.utdallas.edu/2021/undergraduate/programs/ah/philosophy`
 
 > `.requirements`
 >

--- a/docs/schemas/exam.md
+++ b/docs/schemas/exam.md
@@ -70,23 +70,23 @@ CSPlacementExam extends Exam = {
 >
 > The type of exam object this object represents.
 >
-> **Example**: AP
+> **Examples**: `AP`, `CLEP`
 
 > `.yields`
 >
-> **Type**: Array<Outcome>
+> **Type**: Array\<Outcome>
 >
 > An array of `Outcomes` for which the credit for the `Course` or `Credit` is received. Does not include placement, only actual credit.
 >
-> **Example**: [{requirement: ExamRequirement, [[MATH2312._id, MATH 1325._id], [MATH2312._id, MATH2413._id]]}]
+> **Example**: `[{requirement: ExamRequirement, outcome: [[MATH2312._id, MATH 1325._id], [MATH2312._id, MATH2413._id]]}]`
 
 > `.placement`
 >
-> **Type**: Array<Outcome>
+> **Type**: Array\<Outcome>
 >
 > An array of `Outcomes` for which the placement into the `Course` is earned. Does not include credit, only placement into the course.
 >
-> **Example**: [{requirement: ExamRequirement, [[MATH1325._id]]}]
+> **Example**: `[{requirement: ExamRequirement, outcome: [[MATH1325._id, MATH2306._id, MATH2312._id, CS2305._id]]}]`
 
 > `.name`
 >
@@ -94,8 +94,7 @@ CSPlacementExam extends Exam = {
 >
 > The name of the exact exam being taken.
 >
-> **Example**: "Macroeconomics", "American History I: Early Colonization to 1877", "Environmental Systems
-> and Societies"
+> **Examples**: `Macroeconomics`, `American History I: Early Colonization to 1877`, `Environmental Systems and Societies`
 
 > `.level`
 >
@@ -103,7 +102,7 @@ CSPlacementExam extends Exam = {
 >
 > The level of the IB exam.
 >
-> **Example**: Standard, Higher
+> **Examples**: `Standard`, `Higher`
 
 ## Outcome
 
@@ -113,7 +112,7 @@ CSPlacementExam extends Exam = {
 >
 > The requirement to achieve the associated outcome
 >
-> **Example**: ExamRequirement.minimum_score === 4, MajorRequirement.major === "Physics"
+> **Examples**: `ExamRequirement.minimum_score === 4`, `MajorRequirement.major === "Physics"`
 
 > `.outcome`
 >
@@ -122,4 +121,4 @@ CSPlacementExam extends Exam = {
 > The set of sets of `Course`s and `Credit`s which can result (awarded/placed into) should the requirement be met.
 > The outer array contains the possible choices.
 >
-> **Example**: [[MATH2312._id, MATH 1325._id], [MATH2312._id, MATH2413._id]]
+> **Example**: `[[MATH2312._id, MATH 1325._id], [MATH2312._id, MATH2413._id]]`

--- a/docs/schemas/location.md
+++ b/docs/schemas/location.md
@@ -1,9 +1,11 @@
 # Location
+
 ## Overview
 
 A location on the UT Dallas campus.
 
 ## Object Representation
+
 ```ts
 Location = {
     "building": string,
@@ -13,13 +15,14 @@ Location = {
 ```
 
 ## Properties
+
 > `.building`
 >
 > **Type**: string
 >
 > The building of the location.
 >
-> **Example**: "SLC", "ONLINE"
+> **Examples**: `SLC`, `ECSW`
 
 > `.room`
 >
@@ -27,7 +30,7 @@ Location = {
 >
 > The room of the location.
 >
-> **Example**: "2.203", "ONLINE"
+> **Examples**: `2.203`, `1.315`
 
 > `.map_uri`
 >
@@ -35,4 +38,4 @@ Location = {
 >
 > A hyperlink to the UTD room locator.
 >
-> **Example**: https://locator.utdallas.edu/SLC_2.203
+> **Example**: `https://locator.utdallas.edu/SLC_2.203`

--- a/docs/schemas/meeting.md
+++ b/docs/schemas/meeting.md
@@ -1,9 +1,11 @@
 # Meeting
+
 ## Overview
 
 A 'Meeting' represents a recurring meeting. This schema can represent both recurring meetings and single meetings. Meetings occur repeatedly on the specified days of the week during a period. Non-recurring meetings should have the `start_date` equal to the `end_date`.
 
 ## Object Representation
+
 ```ts
 ModalityType = "pending" | "traditional" | "hybrid" | "flexible" | "remote" | "online"
 
@@ -19,13 +21,14 @@ Meeting = {
 ```
 
 ## Properties
+
 > `.start_date`
 >
 > **Type**: string
 >
 > The start date of a meeting.
 >
-> **Example**: January 18, 2022
+> **Example**: `2022-08-22T00:00:00-05:00`
 
 > `.end_date`
 >
@@ -33,15 +36,15 @@ Meeting = {
 >
 > The end date of a meeting.
 >
-> **Example**: May 5, 2022
+> **Example**: `2022-12-08T00:00:00-06:00`
 
 > `.meeting_days`
 >
-> **Type**: Array<string>
+> **Type**: Array\<string>
 >
 > A list of all days the meeting occurs during the time period.
 >
-> **Example**: ["Monday", "Wednesday"]
+> **Example**: `["Monday", "Wednesday"]`
 
 > `.start_time`
 >
@@ -49,7 +52,7 @@ Meeting = {
 >
 > The time the meeting starts on each meeting day.
 >
-> **Example**: "10:00am"
+> **Example**: `0000-01-01T16:00:00-05:50`
 
 > `.end_time`
 >
@@ -57,13 +60,15 @@ Meeting = {
 >
 > The time a meeting ends on each meeting day.
 >
-> **Example**: "11:15am"
+> **Example**: `0000-01-01T17:15:00-05:50`
 
 > `.modality`
 >
 > **Type**: ModalityType
 >
 > The modality of the meeting following the modality types in [UTD's CourseBook](https://coursebook.utdallas.edu/modalities).
+>
+> NOTE: All observed entries of this have been blank, use with caution.
 >
 > **Example**: traditional
 

--- a/docs/schemas/professor.md
+++ b/docs/schemas/professor.md
@@ -1,9 +1,11 @@
 # Professor
+
 ## Overview
 
 A `Professor` represents a professor employed at the University of Texas at Dallas.
 
 ## Object Representation
+
 ```ts
 Professor = {
     "_id": ObjectId,
@@ -21,6 +23,7 @@ Professor = {
 ```
 
 ## Properties
+
 > `._id`
 >
 > **Type**: ObjectId
@@ -47,23 +50,27 @@ Professor = {
 
 > `.titles`
 >
-> **Type**: string
+> **Type**: Array\<string>
 >
 > The professor's titles.
 >
-> **Example**: ["Senior Mathematics Lecturer"], ["Lars Magnus Ericsson Chair", "Dean – Erik Jonsson School of Engineering and Computer Science"]
+> **Example**: `["Senior Mathematics Lecturer"]`, `["Lars Magnus Ericsson Chair", "Dean – Erik Jonsson School of Engineering and Computer Science"]`
 
 > `.email`
 >
 > **Type**: string
 >
 > The professor's email address.
+>
+> **Example**: `xxx555555@utdallas.edu`
 
 > `.phone_number`
 >
 > **Type**: string
 >
 > The professor's phone number.
+>
+> **Example**: `123-456-7890`
 
 > `.office`
 >
@@ -76,21 +83,25 @@ Professor = {
 > **Type**: string
 >
 > A hyperlink pointing to the professor's official university profile.
+>
+> **Example**: `https://profiles.utdallas.edu/stephanie.adams`
 
 > `.image_uri`
 >
 > **Type**: string
-> 
+>
 > A link to the image used for the professor on the professor's official university profile.
+>
+> **Example**: `https://profiles.utdallas.edu/storage/media/2384/conversions/Adams-headshot-1-medium.jpg`
 
 > `.office_hours`
 >
-> **Type**: Array<Meeting>
+> **Type**: Array\<Meeting>
 >
 > A list of all office hours of the professor.
 
 > `.sections`
-> 
-> **Type**: Array<ObjectId>
 >
-> A list of references to sections a professor is currently teaching or has taught. This will be sorted in descending order with respect to `end_date` in the section's `academic_session`.
+> **Type**: Array\<ObjectId>
+>
+> A list of references to sections a professor is currently teaching or has taught. This will be sorted in increasing order with respect to `end_date` in the section's `academic_session`.

--- a/docs/schemas/requirement.md
+++ b/docs/schemas/requirement.md
@@ -1,4 +1,5 @@
 # Requirement
+
 ## Overview
 
 A 'Requirement' represents a requirement that can be satisfied. This is probably the most important concept in the API and also has the most cognitive overhead. `Requirement` is abstract and has multiple classes that derive from it to represent the various types requirements at UTD. An overview of these will be given here:
@@ -60,6 +61,7 @@ A `CoreRequirement` represents the need to have taken a course fulfilling a spec
 An `OtherRequirement` represents some miscellaneous need to satisfy the requirement.
 
 ## Object Representation
+
 ```ts
 RequirementType = "course" | "section" | "exam" | "major" | "minor" | "gpa" | "consent" | "collection" | "hours" | "other"
 
@@ -142,6 +144,7 @@ CoreRequirement extends Requirement {
 ```
 
 ## Properties
+
 > `.type`
 >
 > **Type**: RequirementType
@@ -228,7 +231,7 @@ CoreRequirement extends Requirement {
 >
 > **Type**: string
 >
-> A name for the collection to indicate what it holds. May be empty if not very applicable.
+> A name for the collection to indicate what it holds. May be empty if not applicable.
 >
 > **Example**: "Core Curriculum", "", "Major Requirements"
 
@@ -242,7 +245,7 @@ CoreRequirement extends Requirement {
 
 > `.options`
 >
-> **Type**: Array<Requirement>
+> **Type**: Array\<Requirement>
 >
 > A list of all the options that can contribute to satisfying the requirement.
 >
@@ -268,12 +271,12 @@ CoreRequirement extends Requirement {
 >
 > The core flag that a course meeting this requirement must fulfill.
 >
-> **Example**: "060"
+> **Example**: `060`
 
 > `.hours`
 >
 > **Type**: number
 >
-> The minimum number of credit hours that a course meeting this requirement must fulfill. 
+> The minimum number of credit hours that a course meeting this requirement must fulfill.
 >
 > **Example**: 3

--- a/docs/schemas/section.md
+++ b/docs/schemas/section.md
@@ -1,9 +1,11 @@
 # Section
+
 ## Overview
 
 A `Section` object is the instantiation of a `Course` object with a professor, meeting times, and a grade distribution.
 
 ## Object Representation
+
 ```ts
 Section = {
     "_id": ObjectId,
@@ -24,102 +26,103 @@ Section = {
 ```
 
 ## Properties
+
 > `._id`
-> 
+>
 > **Type**: ObjectId
-> 
+>
 > The MongoDB database id for the `Section` object.
 >
 > **Example**: ObjectId("61ebbb126e3659537e8a14d6")
 
 > `.section_number`
-> 
+>
 > **Type**: string
-> 
+>
 > The section's official number.
-> 
-> **Example**: 002
+>
+> **Examples**: `002`, `3U2`, `0W1`, `HN1`
 
 > `.course_reference`
-> 
+>
 > **Type**: ObjectId
-> 
+>
 > An id that points to the course in MongoDB that this section is an instantiation of.
-> 
-> **Example**:
+>
+> **Example**: ObjectId("653762c456d2f77f0e072e6b")
 
 > `.section_corequisites`
-> 
+>
 > **Type**: CollectionRequirement
-> 
+>
 > A collection of all sections that must be taken alongside this section such as specific labs and exam sections.
 
 > `.academic_session`
-> 
+>
 > **Type**: AcademicSession
-> 
+>
 > The academic session that the section takes place in.
 
 > `.professors`
-> 
-> **Type**: Array<ObjectId>
-> 
-> An array of ids linking to each professor in MongoDB for this section.
+>
+> **Type**: Array\<ObjectId>
+>
+> An array of object IDs linking to each professor in MongoDB for this section.
 
 > `.teaching_assistants`
-> 
-> **Type**: Array<Assistant>
-> 
+>
+> **Type**: Array\<Assistant>
+>
 > An array of all teaching assistants for this section.
 
 > `.internal_class_number`
-> 
+>
 > **Type**: string
-> 
+>
 > The internal (university) number used to reference this section.
-> 
+>
 > **Example**: 82785
 
 > `.instruction_mode`
-> 
+>
 > **Type**: string
-> 
+>
 > The instruction modality for this section.
-> 
-> **Example**: Traditional
+>
+> **Examples**: `Face-to-Face`, `Hybrid/Blended`, `Online`
 
 > `.meetings`
-> 
-> **Type**: Array<Meeting>
-> 
+>
+> **Type**: Array\<Meeting>
+>
 > An array of the locations and times that this section meets.
 
 > `.core_flags`
-> 
-> **Type**: Array<string>
-> 
-> An array of core requirement codes this section fulfills. 
+>
+> **Type**: Array\<string>
+>
+> An array of core requirement codes this section fulfills.
 >
 > **Example**: ["020", "050", ...]
 
 > `.syllabus_uri`
-> 
+>
 > **Type**: string
-> 
+>
 > A link to the syllabus on the web.
-> 
-> **Example**: https://dox.utdallas.edu/syl118093
+>
+> **Example**: `https://dox.utdallas.edu/syl118093`
 
 > `.grade_distribution`
-> 
-> **Type**: Array<number>
-> 
+>
+> **Type**: Array\<number>
+>
 > An array of how many students achieved a certain grade in this section decreating in the order of A+, A, A-, etc.
-> 
+>
 > **Example**: [2, 3, 5, 4, 3, ...]
 
 > `.attributes`
-> 
+>
 > **Type**: Object
-> 
+>
 > Space for additional data describing the section not listed elsewhere.


### PR DESCRIPTION
Improves docs formatting style:
- Blank lines around headers
- Blank lines around code blocks
- Backticks around strings (most have been changed)
- Escape <> tags after `Array`s (previously they were treated as HTML tags, causing them to be rendered as invisible)
- `Example` -> `Examples` if we're listing more than one example
- Remove trailing spaces at ends of lines

Also, fixes up the examples of certain fields like the dates/times and removes examples that don't exist in the database (e.g., most online-referring examples). Additionally, adds a note to the Meeting.modality field indicating there are currently no entries in the database that have that field populated.

Potentially related to #180.