### PR TITLE
Implement singleton pattern for MongoDB instance

### DIFF
--- a/api/controllers/course.go
+++ b/api/controllers/course.go
@@ -17,7 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var courseCollection *mongo.Collection = configs.GetCollection(configs.DB, "courses")
+var courseCollection *mongo.Collection = configs.GetCollection("courses")
 
 func CourseSearch() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/api/controllers/degree.go
+++ b/api/controllers/degree.go
@@ -17,7 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var degreeCollection *mongo.Collection = configs.GetCollection(configs.DB, "degrees")
+var degreeCollection *mongo.Collection = configs.GetCollection("degrees")
 
 func DegreeSearch() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/api/controllers/evaluation.go
+++ b/api/controllers/evaluation.go
@@ -25,7 +25,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var evaluationCollection *mongo.Collection = configs.GetCollection(configs.DB, "evaluations")
+var evaluationCollection *mongo.Collection = configs.GetCollection("evaluations")
 
 func EvalBySectionID(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/api/controllers/exam.go
+++ b/api/controllers/exam.go
@@ -18,7 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var examCollection *mongo.Collection = configs.GetCollection(configs.DB, "exams")
+var examCollection *mongo.Collection = configs.GetCollection("exams")
 
 type examFilter struct {
 	Type  string `schema:"type"`

--- a/api/controllers/professor.go
+++ b/api/controllers/professor.go
@@ -17,7 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var professorCollection *mongo.Collection = configs.GetCollection(configs.DB, "professors")
+var professorCollection *mongo.Collection = configs.GetCollection("professors")
 
 func ProfessorSearch() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/api/controllers/section.go
+++ b/api/controllers/section.go
@@ -17,7 +17,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var sectionCollection *mongo.Collection = configs.GetCollection(configs.DB, "sections")
+var sectionCollection *mongo.Collection = configs.GetCollection("sections")
 
 func SectionSearch() gin.HandlerFunc {
 	return func(c *gin.Context) {


### PR DESCRIPTION
This is my attempt at making the DB instance a singleton pattern. 

The GetCollection function calls ConnectDB everytime its invoked - but the sync package's once.do should prevent from any more instances being created and just return the client from what I understood of documentation. I hope this does the job, if not please let me know what I can change/improve! 