### PR TITLE
Add latitude and longitude to rooms type

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2328,6 +2328,12 @@ const docTemplate = `{
                 "building": {
                     "type": "string"
                 },
+                "lat": {
+                    "type": "number"
+                },
+                "lng": {
+                    "type": "number"
+                },
                 "rooms": {
                     "type": "array",
                     "items": {
@@ -2433,6 +2439,9 @@ const docTemplate = `{
                     }
                 },
                 "course_number": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -260,6 +260,10 @@ definitions:
     properties:
       building:
         type: string
+      lat:
+        type: number
+      lng:
+        type: number
       rooms:
         items:
           $ref: '#/definitions/schema.Room'
@@ -330,6 +334,8 @@ definitions:
           $ref: '#/definitions/schema.AcademicSessionSections'
         type: array
       course_number:
+        type: string
+      title:
         type: string
     type: object
   schema.GradeData:

--- a/api/schema/objects.go
+++ b/api/schema/objects.go
@@ -164,8 +164,10 @@ type MazevoEvent struct {
 
 // Rooms type
 type BuildingRooms struct {
-	Building string `bson:"building" json:"building"`
-	Rooms    []Room `bson:"rooms" json:"rooms"`
+	Building string  `bson:"building" json:"building"`
+	Rooms    []Room  `bson:"rooms" json:"rooms"`
+	Lat      float64 `bson:"lat" json:"lat"`
+	Lng      float64 `bson:"lng" json:"lng"`
 }
 type Room struct {
 	Room     string `bson:"room" json:"room"`


### PR DESCRIPTION
I'll change the aggregation pipeline like so, adding the last 4 stages, after merge:
```
[
  {
    $project: {
      buildings: 1
    }
  },
  {
    $unionWith: {
      coll: "mazevo"
    }
  },
  {
    $unwind: "$buildings"
  },
  {
    $unwind: "$buildings.rooms"
  },
  {
    $project: {
      building: "$buildings.building",
      room: "$buildings.rooms.room",
      capacity: null
    }
  },
  {
    $unionWith: {
      coll: "astra",
      pipeline: [
        {
          $unwind: "$buildings"
        },
        {
          $unwind: "$buildings.rooms"
        },
        {
          $project: {
            building: "$buildings.building",
            room: "$buildings.rooms.room",
            capacity: {
              $first:
                "$buildings.rooms.events.capacity"
            }
          }
        }
      ]
    }
  },
  {
    $group: {
      _id: {
        building: "$building",
        room: "$room"
      },
      capacity: {
        $max: "$capacity"
      }
    }
  },
  {
    $group: {
      _id: "$_id.building",
      rooms: {
        $push: {
          room: "$_id.room",
          capacity: "$capacity"
        }
      }
    }
  },
  {
    $project: {
      _id: 0,
      building: "$_id",
      rooms: 1
    }
  },
  {
    $lookup: {
      from: "mapLocations",
      localField: "building",
      foreignField: "acronym",
      as: "location"
    }
  },
  {
    $unwind: {
      path: "$location",
      preserveNullAndEmptyArrays: true
    }
  },
  {
    $addFields: {
      lat: {
        $ifNull: ["$location.lat", null]
      },
      lng: {
        $ifNull: ["$location.lng", null]
      }
    }
  },
  {
    $project: {
      building: 1,
      rooms: 1,
      lat: 1,
      lng: 1
    }
  }
]
```