### PR TITLE
add new Signed URL endpoint

### DIFF
--- a/api/controllers/storage.go
+++ b/api/controllers/storage.go
@@ -323,5 +323,5 @@ func ObjectSignedURL(c *gin.Context) {
 		return
 	}
 
-	respond(c, http.StatusOK, "Created SignUrl", url)
+	respond(c, http.StatusOK, "success", url)
 }

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1901,6 +1901,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/storage/{bucket}/{objectID}/url": {
+            "put": {
+                "description": "\"Create's a new signed URL for target object\"",
+                "consumes": [
+                    "application/json"
+                ],
+                "operationId": "objectUploadURL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of the bucket",
+                        "name": "bucket",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "ID of the object",
+                        "name": "objectID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "params for Signed URL",
+                        "name": "method",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ObjectSignedURLBody"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The internal storage key",
+                        "name": "x-storage-key",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Presigned url for the target Object",
+                        "schema": {
+                            "$ref": "#/definitions/schema.APIResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "A string describing the error",
+                        "schema": {
+                            "$ref": "#/definitions/schema.APIResponse-string"
+                        }
+                    }
+                }
+            }
+        },
         "/swagger/{file}": {
             "get": {
                 "security": [],
@@ -1924,6 +1979,28 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "controllers.ObjectSignedURLBody": {
+            "description": "request body",
+            "type": "object",
+            "properties": {
+                "expiration": {
+                    "description": "timestamp for when the signed URL will expire",
+                    "type": "string"
+                },
+                "headers": {
+                    "description": "headers for signed URL",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "method": {
+                    "description": "method to be used with signed URL",
+                    "type": "string",
+                    "example": "PUT"
+                }
+            }
+        },
         "schema.APIResponse-array_int": {
             "type": "object",
             "properties": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1,4 +1,20 @@
 definitions:
+  controllers.ObjectSignedURLBody:
+    description: request body
+    properties:
+      expiration:
+        description: timestamp for when the signed URL will expire
+        type: string
+      headers:
+        description: headers for signed URL
+        items:
+          type: string
+        type: array
+      method:
+        description: method to be used with signed URL
+        example: PUT
+        type: string
+    type: object
   schema.APIResponse-array_int:
     properties:
       data:
@@ -1919,6 +1935,43 @@ paths:
           description: The object's info
           schema:
             $ref: '#/definitions/schema.APIResponse-schema_ObjectInfo'
+        "500":
+          description: A string describing the error
+          schema:
+            $ref: '#/definitions/schema.APIResponse-string'
+  /storage/{bucket}/{objectID}/url:
+    put:
+      consumes:
+      - application/json
+      description: '"Create''s a new signed URL for target object"'
+      operationId: objectUploadURL
+      parameters:
+      - description: Name of the bucket
+        in: path
+        name: bucket
+        required: true
+        type: string
+      - description: ID of the object
+        in: path
+        name: objectID
+        required: true
+        type: string
+      - description: params for Signed URL
+        in: body
+        name: method
+        required: true
+        schema:
+          $ref: '#/definitions/controllers.ObjectSignedURLBody'
+      - description: The internal storage key
+        in: header
+        name: x-storage-key
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Presigned url for the target Object
+          schema:
+            $ref: '#/definitions/schema.APIResponse-string'
         "500":
           description: A string describing the error
           schema:

--- a/api/routes/storage.go
+++ b/api/routes/storage.go
@@ -59,7 +59,7 @@ func StorageRoute(router *gin.Engine) {
 		return
 	}
 
-	//Rescrict with password
+	// Rescrict with password
 	authMiddleware := func(c *gin.Context) {
 		secret := c.GetHeader("x-storage-key")
 		expected, exist := os.LookupEnv("STORAGE_ROUTE_KEY")
@@ -79,7 +79,7 @@ func StorageRoute(router *gin.Engine) {
 	// All routes related to storage come here
 	storageGroup := router.Group("/storage")
 
-	//Use auth
+	// Use auth
 	storageGroup.Use(authMiddleware)
 
 	storageGroup.OPTIONS("", controllers.Preflight)
@@ -88,4 +88,5 @@ func StorageRoute(router *gin.Engine) {
 	storageGroup.GET(":bucket/:objectID", controllers.ObjectInfo)
 	storageGroup.POST(":bucket/:objectID", controllers.PostObject)
 	storageGroup.DELETE(":bucket/:objectID", controllers.DeleteObject)
+	storageGroup.PUT(":bucket/:objectID/url", controllers.ObjectSignedURL)
 }


### PR DESCRIPTION
added a new endpoint `/storage/:bucket/:objectID/url` for creating Signed URLs to be used for uploading files or limited downloads. accepts options for expiration time and headers so that projects can set for example, expiration time, MIME type, max content length, etc.

This also removes the ACL set when using PostObject,  letting either bucket level ACLs or Uniform Bucket Level policies control default behavior. if needed projects can use headers on Signed URLs to set ACL policies.