### PR TITLE
refactor: unify query builders with generic GetQuery[T]

### DIFF
--- a/api/controllers/course.go
+++ b/api/controllers/course.go
@@ -48,9 +48,8 @@ func CourseSearch(c *gin.Context) {
 	var courses []schema.Course
 
 	// build query key value pairs (only one value per key)
-	query, err := schema.FilterQuery[schema.Course](c)
+	query, err := GetQuery[schema.Course]("Search", c)
 	if err != nil {
-		respond(c, http.StatusBadRequest, "schema validation error", err.Error())
 		return
 	}
 
@@ -91,13 +90,13 @@ func CourseById(c *gin.Context) {
 	var course schema.Course
 
 	// parse object id from id parameter
-	objId, err := objectIDFromParam(c, "id")
+	objId, err := GetQuery[schema.Course]("ById", c)
 	if err != nil {
 		return
 	}
 
 	// find and parse matching course
-	err = courseCollection.FindOne(ctx, bson.M{"_id": objId}).Decode(&course)
+	err = courseCollection.FindOne(ctx, objId).Decode(&course)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return
@@ -191,10 +190,8 @@ func courseSection(flag string, c *gin.Context) {
 	switch flag {
 	case "Search":
 		// filter courses based on the query parameters, build the key-value pair
-		courseQuery, err = schema.FilterQuery[schema.Course](c)
+		courseQuery, err = GetQuery[schema.Course](flag, c)
 		if err != nil {
-			// return the validation error if there's anything wrong
-			respond(c, http.StatusBadRequest, "schema validation error", err.Error())
 			return
 		}
 	case "ById":

--- a/api/controllers/grades.go
+++ b/api/controllers/grades.go
@@ -184,11 +184,9 @@ func gradesAggregation(flag string, c *gin.Context) {
 
 	if flag == "course_endpoint" || flag == "section_endpoint" || flag == "professor_endpoint" {
 		// parse object id from id parameter
-		objId, err = objectIDFromParam(c, "id")
-		if err != nil {
-			return
-		}
-	}
+filter, err := GetQuery[schema.Course]("ById", c) // for course_endpoint
+if err != nil { return }
+courseMatch := bson.D{{Key: "$match", Value: filter}}
 
 	professor := (first_name != "" || last_name != "")
 

--- a/api/controllers/professor.go
+++ b/api/controllers/professor.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"time"
 
@@ -208,7 +207,7 @@ func professorCourse(flag string, c *gin.Context) {
 	defer cancel()
 
 	// determine the professor's query
-	if professorQuery, err = getProfessorQuery(flag, c); err != nil {
+	if professorQuery, err = GetQuery[schema.Professor](flag, c); err != nil {
 		return // if there's an error, the response will have already been thrown to the consumer, halt the funcion here
 	}
 
@@ -339,7 +338,7 @@ func professorSection(flag string, c *gin.Context) {
 	defer cancel()
 
 	// determine the professor's query
-	if professorQuery, err = getProfessorQuery(flag, c); err != nil {
+	if professorQuery, err = GetQuery[schema.Professor](flag, c); err != nil {
 		return
 	}
 
@@ -400,35 +399,6 @@ func professorSection(flag string, c *gin.Context) {
 		return
 	}
 	respond(c, http.StatusOK, "success", professorSections)
-}
-
-// determine the query of the professor based on the parameters passed from context
-// if there's an error, throw an error response back to the API consumer and return only the error
-func getProfessorQuery(flag string, c *gin.Context) (bson.M, error) {
-	var professorQuery bson.M
-	var err error
-
-	switch flag {
-	case "Search":
-		// if the flag is Search, filter professors based on query parameters
-		professorQuery, err = schema.FilterQuery[schema.Professor](c)
-		if err != nil {
-			respond(c, http.StatusBadRequest, "schema validation error", err.Error())
-			return nil, err
-		}
-	case "ById":
-		// if the flag is ById, filter that single professor based on their _id
-		objId, err := objectIDFromParam(c, "id")
-		if err != nil {
-			return nil, err
-		}
-		professorQuery = bson.M{"_id": objId}
-	default:
-		err = errors.New("invalid type of filtering professors, either filtering based on available professor fields or ID")
-		respondWithInternalError(c, err)
-		return nil, err
-	}
-	return professorQuery, err
 }
 
 // @Id				trendsProfessorSectionSearch

--- a/api/controllers/section.go
+++ b/api/controllers/section.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"time"
 
@@ -177,7 +176,7 @@ func sectionCourse(flag string, c *gin.Context) {
 	var sectionCourses []schema.Course
 	var sectionQuery bson.M
 	var err error
-	if sectionQuery, err = getSectionQuery(flag, c); err != nil {
+	if sectionQuery, err = GetQuery[schema.Section](flag, c); err != nil {
 		return
 	}
 
@@ -304,7 +303,7 @@ func sectionProfessor(flag string, c *gin.Context) {
 	var sectionProfessors []schema.Professor
 	var sectionQuery bson.M
 	var err error
-	if sectionQuery, err = getSectionQuery(flag, c); err != nil {
+	if sectionQuery, err = GetQuery[schema.Section](flag, c); err != nil {
 		return
 	}
 
@@ -356,32 +355,4 @@ func sectionProfessor(flag string, c *gin.Context) {
 	}
 
 	respond(c, http.StatusOK, "success", sectionProfessors)
-}
-
-// Determine the query of the section based on parameters passed from context.
-func getSectionQuery(flag string, c *gin.Context) (bson.M, error) {
-	var sectionQuery bson.M
-	var err error
-
-	switch flag {
-	case "Search":
-		sectionQuery, err = schema.FilterQuery[schema.Section](c)
-		if err != nil {
-			respond(c, http.StatusBadRequest, "schema validation error", err.Error())
-			return nil, err
-		}
-	case "ById":
-		sectionId, err := objectIDFromParam(c, "id")
-		if err != nil {
-			respond(c, http.StatusBadRequest, "invalid section id error", err.Error())
-			return nil, err
-		}
-		sectionQuery = bson.M{"_id": sectionId}
-	default:
-		err = errors.New("invalid type of filtering sections, either on fields or ids")
-		respondWithInternalError(c, err)
-		return nil, err
-	}
-
-	return sectionQuery, nil
 }


### PR DESCRIPTION
Replaced per-endpoint query functions with a generic GetQuery[T] in controllers. This removes duplication, standardizes Search/ById handling, and simplifies future maintenance.