### PR TITLE
Add multi email recipients

### DIFF
--- a/api/controllers/email.go
+++ b/api/controllers/email.go
@@ -29,6 +29,9 @@ import (
 // @Failure		500					{object}	schema.APIResponse[string]				"A string describing the error"
 // @Failure		400					{object}	schema.APIResponse[string]				"A string describing the error"
 func SendEmail(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+
 	var req schema.EmailRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -61,7 +64,7 @@ func SendEmail(c *gin.Context) {
 		m.EmbedReader(emb.Name, bytes.NewReader(emb.Data), mail.WithFileContentID(emb.Name))
 	}
 
-	if err := client.DialAndSend(m); err != nil {
+	if err := client.DialAndSendWithContext(ctx, m); err != nil {
 		respond(c, http.StatusInternalServerError, "failed to send email", err.Error())
 		return
 	}

--- a/api/controllers/email.go
+++ b/api/controllers/email.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -42,7 +43,7 @@ func SendEmail(c *gin.Context) {
 		return
 	}
 
-	if err := m.To(req.To); err != nil {
+	if err := m.To(req.To[0]); err != nil {
 		respond(c, http.StatusBadRequest, "invalid to address", err.Error())
 		return
 	}
@@ -77,7 +78,7 @@ func SendEmail(c *gin.Context) {
 // @Success		200					{object}	schema.APIResponse[schema.EmailRequest]	"Email Request Body with Queued Task Name"
 // @Failure		500					{object}	schema.APIResponse[string]				"A string describing the error"
 // @Failure		400					{object}	schema.APIResponse[string]				"A string describing the error"
-func QueueEmail(c *gin.Context) {
+func QueueEmail(c *gin.Context) { // TODO: Update Swaggo!
 	// Request must be able to bind to email request
 	var emailReq schema.EmailRequest
 	if err := c.ShouldBindJSON(&emailReq); err != nil {
@@ -85,43 +86,54 @@ func QueueEmail(c *gin.Context) {
 		return
 	}
 
-	body, err := json.Marshal(emailReq)
-	if err != nil {
-		respond(c, http.StatusInternalServerError, "failed to serialize email request", err.Error())
-		return
-	}
-
 	client := c.MustGet("tasksClient").(*cloudtasks.Client)
-
 	queuePath := os.Getenv("GCLOUD_EMAIL_QUEUE_PATH")
 	queueUrl := os.Getenv("GCLOUD_EMAIL_QUEUE_URL")
 
-	// Build the Task payload.
-	// https://docs.cloud.google.com/tasks/docs/creating-http-target-tasks
-	taskReq := &taskspb.CreateTaskRequest{
-		Parent: queuePath,
-		Task: &taskspb.Task{
-			MessageType: &taskspb.Task_HttpRequest{
-				HttpRequest: &taskspb.HttpRequest{
-					HttpMethod: taskspb.HttpMethod_POST,
-					Url:        queueUrl,
-					Headers: map[string]string{
-						"x-email-send-key": os.Getenv("EMAIL_SEND_ROUTE_KEY"), // Must get from env bc queue only has x-email-queue-key header
-						"x-api-key":        c.GetHeader("x-api-key"),
+	baseEmailReq := emailReq
+	baseEmailReq.To = []string{}
+
+	queuedTasks := []string{}
+
+	numOfRecipients := len(emailReq.To)
+	for i, to := range emailReq.To {
+		baseEmailReq.To = []string{to}
+
+		body, err := json.Marshal(baseEmailReq)
+		if err != nil {
+			respond(c, http.StatusInternalServerError, fmt.Sprintf("failed to serialize email request for recipient %s %d/%d", to, i, numOfRecipients), err.Error())
+			return
+		}
+
+		// Build the Task payload.
+		// // https://docs.cloud.google.com/tasks/docs/creating-http-target-tasks
+		taskReq := &taskspb.CreateTaskRequest{
+			Parent: queuePath,
+			Task: &taskspb.Task{
+				MessageType: &taskspb.Task_HttpRequest{
+					HttpRequest: &taskspb.HttpRequest{
+						HttpMethod: taskspb.HttpMethod_POST,
+						Url:        queueUrl,
+						Headers: map[string]string{
+							"x-email-send-key": os.Getenv("EMAIL_SEND_ROUTE_KEY"), // Must get from env bc queue only has x-email-queue-key header
+							"x-api-key":        c.GetHeader("x-api-key"),
+						},
 					},
 				},
 			},
-		},
+		}
+
+		// Add a payload message if one is present.
+		taskReq.Task.GetHttpRequest().Body = []byte(body)
+
+		task, err := client.CreateTask(c.Request.Context(), taskReq)
+		if err != nil {
+			respond(c, http.StatusInternalServerError, fmt.Sprintf("failed to queue email for recipient %s %d/%d", to, i, numOfRecipients), err.Error())
+			return
+		}
+		
+		queuedTasks = append(queuedTasks, task.GetName())
 	}
 
-	// Add a payload message if one is present.
-	taskReq.Task.GetHttpRequest().Body = []byte(body)
-
-	task, err := client.CreateTask(c.Request.Context(), taskReq)
-	if err != nil {
-		respond(c, http.StatusInternalServerError, "failed to queue email", err.Error())
-		return
-	}
-
-	respond(c, http.StatusOK, "success", task.GetName())
+	respond(c, http.StatusOK, "success", queuedTasks)
 }

--- a/api/controllers/email.go
+++ b/api/controllers/email.go
@@ -72,12 +72,12 @@ func SendEmail(c *gin.Context) {
 // @Tags			Internal
 // @Description	"Queue an email to be sent via SMTP. Multi-recipient emails will be queued as separate emails to avoid bypassing queueing system. This route is restricted to only Nebula Labs internal Projects."
 // @Accept			json
-// @Produce			json
-// @Param			request				body		schema.EmailRequest						true	"Email Request Body"
-// @Param			x-email-queue-key	header		string									true	"The internal email queue key"
-// @Success		200					{object}	schema.APIResponse[[]string]				"The list of queued task names"
-// @Failure		500					{object}	schema.APIResponse[string]				"A string describing the error"
-// @Failure		400					{object}	schema.APIResponse[string]				"A string describing the error"
+// @Produce		json
+// @Param			request				body		schema.EmailRequest				true	"Email Request Body"
+// @Param			x-email-queue-key	header		string							true	"The internal email queue key"
+// @Success		200					{object}	schema.APIResponse[[]string]	"The list of queued task names"
+// @Failure		500					{object}	schema.APIResponse[string]		"A string describing the error"
+// @Failure		400					{object}	schema.APIResponse[string]		"A string describing the error"
 func QueueEmail(c *gin.Context) {
 	// Request must be able to bind to email request
 	var emailReq schema.EmailRequest
@@ -131,7 +131,7 @@ func QueueEmail(c *gin.Context) {
 			respond(c, http.StatusInternalServerError, fmt.Sprintf("failed to queue email for recipient %s %d/%d", to, i, numOfRecipients), err.Error())
 			return
 		}
-		
+
 		queuedTasks = append(queuedTasks, task.GetName())
 	}
 

--- a/api/controllers/email.go
+++ b/api/controllers/email.go
@@ -43,8 +43,8 @@ func SendEmail(c *gin.Context) {
 		return
 	}
 
-	if err := m.To(req.To[0]); err != nil {
-		respond(c, http.StatusBadRequest, "invalid to address", err.Error())
+	if err := m.To(req.To...); err != nil {
+		respond(c, http.StatusBadRequest, "invalid to address(es)", err.Error())
 		return
 	}
 
@@ -70,15 +70,15 @@ func SendEmail(c *gin.Context) {
 // @Id				QueueEmail
 // @Router			/email/queue [post]
 // @Tags			Internal
-// @Description	"Queue an email to be sent via SMTP. This route is restricted to only Nebula Labs internal Projects."
+// @Description	"Queue an email to be sent via SMTP. Multi-recipient emails will be queued as separate emails to avoid bypassing queueing system. This route is restricted to only Nebula Labs internal Projects."
 // @Accept			json
-// @Produce		json
+// @Produce			json
 // @Param			request				body		schema.EmailRequest						true	"Email Request Body"
 // @Param			x-email-queue-key	header		string									true	"The internal email queue key"
-// @Success		200					{object}	schema.APIResponse[schema.EmailRequest]	"Email Request Body with Queued Task Name"
+// @Success		200					{object}	schema.APIResponse[[]string]				"The list of queued task names"
 // @Failure		500					{object}	schema.APIResponse[string]				"A string describing the error"
 // @Failure		400					{object}	schema.APIResponse[string]				"A string describing the error"
-func QueueEmail(c *gin.Context) { // TODO: Update Swaggo!
+func QueueEmail(c *gin.Context) {
 	// Request must be able to bind to email request
 	var emailReq schema.EmailRequest
 	if err := c.ShouldBindJSON(&emailReq); err != nil {

--- a/api/controllers/email.go
+++ b/api/controllers/email.go
@@ -2,10 +2,12 @@ package controllers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/UTDNebula/nebula-api/api/schema"
 	"github.com/gin-gonic/gin"
@@ -79,6 +81,9 @@ func SendEmail(c *gin.Context) {
 // @Failure		500					{object}	schema.APIResponse[string]		"A string describing the error"
 // @Failure		400					{object}	schema.APIResponse[string]		"A string describing the error"
 func QueueEmail(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+
 	// Request must be able to bind to email request
 	var emailReq schema.EmailRequest
 	if err := c.ShouldBindJSON(&emailReq); err != nil {
@@ -126,7 +131,7 @@ func QueueEmail(c *gin.Context) {
 		// Add a payload message if one is present.
 		taskReq.Task.GetHttpRequest().Body = []byte(body)
 
-		task, err := client.CreateTask(c.Request.Context(), taskReq)
+		task, err := client.CreateTask(ctx, taskReq)
 		if err != nil {
 			respond(c, http.StatusInternalServerError, fmt.Sprintf("failed to queue email for recipient %s %d/%d", to, i, numOfRecipients), err.Error())
 			return

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1039,7 +1039,7 @@ const docTemplate = `{
         },
         "/email/queue": {
             "post": {
-                "description": "\"Queue an email to be sent via SMTP. This route is restricted to only Nebula Labs internal Projects.\"",
+                "description": "\"Queue an email to be sent via SMTP. Multi-recipient emails will be queued as separate emails to avoid bypassing queueing system. This route is restricted to only Nebula Labs internal Projects.\"",
                 "consumes": [
                     "application/json"
                 ],
@@ -1070,9 +1070,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Email Request Body with Queued Task Name",
+                        "description": "The list of queued task names",
                         "schema": {
-                            "$ref": "#/definitions/schema.APIResponse-schema_EmailRequest"
+                            "$ref": "#/definitions/schema.APIResponse-array_string"
                         }
                     },
                     "400": {
@@ -3442,6 +3442,23 @@ const docTemplate = `{
                 }
             }
         },
+        "schema.APIResponse-array_string": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                }
+            }
+        },
         "schema.APIResponse-int": {
             "type": "object",
             "properties": {
@@ -4133,7 +4150,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "to": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -109,6 +109,17 @@ definitions:
       status:
         type: integer
     type: object
+  schema.APIResponse-array_string:
+    properties:
+      data:
+        items:
+          type: string
+        type: array
+      message:
+        type: string
+      status:
+        type: integer
+    type: object
   schema.APIResponse-int:
     properties:
       data:
@@ -556,7 +567,9 @@ definitions:
       subject:
         type: string
       to:
-        type: string
+        items:
+          type: string
+        type: array
     required:
     - body
     - subject
@@ -1666,8 +1679,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: '"Queue an email to be sent via SMTP. This route is restricted
-        to only Nebula Labs internal Projects."'
+      description: '"Queue an email to be sent via SMTP. Multi-recipient emails will
+        be queued as separate emails to avoid bypassing queueing system. This route
+        is restricted to only Nebula Labs internal Projects."'
       operationId: QueueEmail
       parameters:
       - description: Email Request Body
@@ -1685,9 +1699,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: Email Request Body with Queued Task Name
+          description: The list of queued task names
           schema:
-            $ref: '#/definitions/schema.APIResponse-schema_EmailRequest'
+            $ref: '#/definitions/schema.APIResponse-array_string'
         "400":
           description: A string describing the error
           schema:

--- a/api/schema/objects.go
+++ b/api/schema/objects.go
@@ -387,7 +387,7 @@ type EmailAttachment struct {
 
 type EmailRequest struct {
 	From        string            `json:"from,omitempty"`
-	To          string            `json:"to" binding:"required,email"`
+	To          []string          `json:"to" binding:"required,dive,email"`
 	Subject     string            `json:"subject" binding:"required"`
 	Body        string            `json:"body" binding:"required"`
 	Attachments []EmailAttachment `json:"attachments,omitempty"`


### PR DESCRIPTION
The email endpoint should have a way to send emails to multiple recipients with one request.
To avoid hitting any SMTP limits, multi recipient emails are not allowed for `/email/queue`, so having more than one string in the "to" array results in a google cloud task being created for each recipient. 
`/email/send` does allow multi recipients in one email, but probably shouldn't be used that way since it bypasses the queueing and could cause the api to hit the SMTP limit.

I'm not 100% on how I've implemented this PR, so I can definitely make any changes if we want a different behavior for multi-recipients.