### PR TITLE
Fix email queueing timeout for large amounts of emails

### DIFF
--- a/api/controllers/email.go
+++ b/api/controllers/email.go
@@ -84,9 +84,6 @@ func SendEmail(c *gin.Context) {
 // @Failure		500					{object}	schema.APIResponse[string]		"A string describing the error"
 // @Failure		400					{object}	schema.APIResponse[string]		"A string describing the error"
 func QueueEmail(c *gin.Context) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
-	defer cancel()
-
 	// Request must be able to bind to email request
 	var emailReq schema.EmailRequest
 	if err := c.ShouldBindJSON(&emailReq); err != nil {
@@ -105,6 +102,9 @@ func QueueEmail(c *gin.Context) {
 
 	numOfRecipients := len(emailReq.To)
 	for i, to := range emailReq.To {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
 		baseEmailReq.To = []string{to}
 
 		body, err := json.Marshal(baseEmailReq)


### PR DESCRIPTION
Google Clout Tasks can take 0.5 seconds per task queued and doesn't allow queueing many tasks at once (to my knowledge and in my research). Since Emails use Gcloud Tasks, the previous 10 second timeout could run out when queueing too many emails at once. This PR makes the timeout a 10 second timeout per Gcloud Task rather than overall. 