### PR TITLE
Update the schema to work on 18 grade distribution

### DIFF
--- a/rest/controllers/grades.go
+++ b/rest/controllers/grades.go
@@ -374,7 +374,7 @@ func gradesAggregation(flag string, c *gin.Context) {
 	switch flag {
 	case "overall", "course_endpoint", "section_endpoint", "professor_endpoint":
 		// combine all semester grade_distributions
-		overallResponse := [14]int{}
+		overallResponse := [18]int{}
 		for _, sem := range grades {
 			for i, grade := range sem.GradeDistribution {
 				overallResponse[i] += grade
@@ -494,7 +494,6 @@ func sumGradesStage() bson.D {
 	}
 }
 
-// Stage to group grade distribution
 func groupGradeDistributionStage(flag string) bson.D {
 	var groupDistributionID any = "$_id.academic_session"
 	// Add the section-type criteria
@@ -514,7 +513,10 @@ func groupGradeDistributionStage(flag string) bson.D {
 	}
 }
 
-// Additional stages for "section-type" pipeline
+// --------------------------------------------------------
+// NOTE: Additional stages for the section-type pipeline
+// --------------------------------------------------------
+
 // Stage to sort the section-type-specific grade distributions before grouping
 func sortGradeDistributionsStage() bson.D {
 	return bson.D{

--- a/rest/schema/objects.go
+++ b/rest/schema/objects.go
@@ -247,16 +247,17 @@ type MapBuilding struct {
 	Lng     *float64 `bson:"lng" json:"lng"`
 }
 
+// The grades distribution: "A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "D-", "F", "W", "P", "CR", "NC", "I"
 type GradeData struct {
 	Id                string  `bson:"_id" json:"_id"`
-	GradeDistribution [14]int `bson:"grade_distribution" json:"grade_distribution"`
+	GradeDistribution [18]int `bson:"grade_distribution" json:"grade_distribution"`
 }
 
 type TypedGradeData struct {
 	Id   string `bson:"_id" json:"_id"`
 	Data []struct {
 		Type              string  `bson:"type" json:"type"`
-		GradeDistribution [14]int `bson:"grade_distribution" json:"grade_distribution"`
+		GradeDistribution [18]int `bson:"grade_distribution" json:"grade_distribution"`
 	} `bson:"data" json:"data"`
 }
 


### PR DESCRIPTION
Update the schema `GradeData` and `TypedGradeData` so it can parse the 18-element grade distribution from MongoDB.

If you want to test this PR locally, you should connect to the dev database instead of prod one. 

