### PR TITLE
Sort courses

### DIFF
--- a/rest/configs/setup.go
+++ b/rest/configs/setup.go
@@ -57,27 +57,24 @@ func GetCollection(collectionName string) *mongo.Collection {
 	return collection
 }
 
-// Returns *options.FindOptions with a limit and offset applied.
+// Returns the offset and limit for pagination options
 // Produces an error if user-provided offset isn't able to be parsed.
-func GetOptionLimit(query *bson.M, c *gin.Context) (*options.FindOptions, error) {
-	delete(*query, "offset") // removes offset (if present) in query --offset is not field in collections
+func GetLimit(query *bson.M, c *gin.Context) (int64, int64, error) {
+	// Removes offset (if present) in query since is not field in collections
+	delete(*query, "offset")
 
-	// parses offset if included in the query
-	var offset int64
+	var offset int64 = 0 // Init the default value of offset
+	var limit = GetEnvLimit()
 	var err error
 
-	var limit int64 = GetEnvLimit()
-
-	if c.Query("offset") == "" {
-		offset = 0 // default value for offset
-	} else {
+	if c.Query("offset") != "" {
 		offset, err = strconv.ParseInt(c.Query("offset"), 10, 64)
 		if err != nil {
-			return options.Find().SetSkip(0).SetLimit(limit), err // default value for offset
+			return -1, -1, err
 		}
 	}
 
-	return options.Find().SetSkip(offset).SetLimit(limit), err
+	return offset, limit, nil
 }
 
 // Returns the offsets and limit for pagination stage for aggregate endpoints pipeline

--- a/rest/configs/setup_test.go
+++ b/rest/configs/setup_test.go
@@ -8,8 +8,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// TestGetOptionLimit checks if the function correctly parses offset from query params
-func TestGetOptionLimit(t *testing.T) {
+// TestGetLimit checks if the function correctly parses offset from query params
+func TestGetLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("ValidOffset", func(t *testing.T) {
@@ -18,8 +18,7 @@ func TestGetOptionLimit(t *testing.T) {
 		c.Request = httptest.NewRequest("GET", "/?offset=25", nil)
 
 		query := bson.M{"offset": "should-be-deleted"}
-		options, err := GetOptionLimit(&query, c)
-
+		offset, _, err := GetLimit(&query, c)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err) // Use Fatalf to stop if options is nil
 		}
@@ -29,8 +28,8 @@ func TestGetOptionLimit(t *testing.T) {
 		}
 
 		// Ensure we compare the same types (int64)
-		if options.Skip == nil || *options.Skip != int64(25) {
-			t.Errorf("Expected Skip to be 25, got %v", options.Skip)
+		if offset != int64(25) {
+			t.Errorf("Expected offset to be 25, got %v", offset)
 		}
 	})
 
@@ -39,10 +38,13 @@ func TestGetOptionLimit(t *testing.T) {
 		c.Request = httptest.NewRequest("GET", "/", nil)
 
 		query := bson.M{}
-		options, _ := GetOptionLimit(&query, c)
+		offset, _, err := GetLimit(&query, c)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
-		if options.Skip == nil || *options.Skip != int64(0) {
-			t.Errorf("Expected default Skip to be 0, got %v", options.Skip)
+		if offset != int64(0) {
+			t.Errorf("Expected default offset to be 0, got %v", offset)
 		}
 	})
 
@@ -51,8 +53,7 @@ func TestGetOptionLimit(t *testing.T) {
 		c.Request = httptest.NewRequest("GET", "/?offset=not-a-number", nil)
 
 		query := bson.M{}
-		_, err := GetOptionLimit(&query, c)
-
+		_, _, err := GetLimit(&query, c)
 		if err == nil {
 			t.Error("Expected an error when parsing a non-integer offset")
 		}

--- a/rest/controllers/controller_utils.go
+++ b/rest/controllers/controller_utils.go
@@ -15,6 +15,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// Map from schema type to the aggregated field
+var typeToField = map[string]string{
+	"Course":    "courses",
+	"Section":   "sections",
+	"Professor": "professors",
+}
+
 // Sets the API's response to a request, producing valid JSON given a status code and data.
 func respond[T any](c *gin.Context, status int, message string, data T) {
 	c.JSON(

--- a/rest/controllers/controller_utils.go
+++ b/rest/controllers/controller_utils.go
@@ -22,6 +22,22 @@ var typeToField = map[string]string{
 	"Professor": "professors",
 }
 
+func getSort(schemaType string) bson.D {
+	switch schemaType {
+	case "Course":
+		return bson.D{
+			{Key: "subject_prefix", Value: 1},
+			{Key: "course_number", Value: 1},
+			{Key: "catalog_year", Value: 1},
+			{Key: "_id", Value: 1},
+		}
+	case "Section", "Professor":
+		return bson.D{{Key: "_id", Value: 1}}
+	default:
+		panic("invalid schema: " + schemaType)
+	}
+}
+
 // Sets the API's response to a request, producing valid JSON given a status code and data.
 func respond[T any](c *gin.Context, status int, message string, data T) {
 	c.JSON(

--- a/rest/controllers/course.go
+++ b/rest/controllers/course.go
@@ -59,13 +59,7 @@ func CourseSearch(c *gin.Context) {
 		respond(c, http.StatusBadRequest, "offset is not type integer", err.Error())
 		return
 	}
-	opts := options.Find().
-		SetSort(bson.D{
-			{Key: "subject_prefix", Value: 1},
-			{Key: "course_number", Value: 1},
-			{Key: "catalog_year", Value: 1},
-		}).
-		SetSkip(offset).SetLimit(limit)
+	opts := options.Find().SetSort(getSort("Course")).SetSkip(offset).SetLimit(limit)
 
 	// Get cursor for query results
 	cursor, err := courseCollection.Find(ctx, query, opts)
@@ -270,12 +264,16 @@ func courseAggregate[T any](flag string, c *gin.Context) {
 
 // buildCoursePipeline builds the pipeline to aggregate the list of object from list of courses
 func buildCoursePipeline(schemaType string, courseQuery bson.M, paginateMap map[string]bson.D) mongo.Pipeline {
-	lookupSection := mongo.Pipeline{
+	field := typeToField[schemaType]
+	filterCourse := mongo.Pipeline{
 		bson.D{{Key: "$match", Value: courseQuery}},
 
+		bson.D{{Key: "$sort", Value: getSort("Course")}},
 		paginateMap["former_offset"],
 		paginateMap["limit"],
+	}
 
+	var lookup = mongo.Pipeline{
 		// Lookup the list of sections from the courses
 		bson.D{{Key: "$lookup", Value: bson.D{
 			{Key: "from", Value: "sections"},
@@ -284,22 +282,20 @@ func buildCoursePipeline(schemaType string, courseQuery bson.M, paginateMap map[
 			{Key: "as", Value: "sections"},
 		}}},
 	}
-
-	var lookupProf, dedup mongo.Pipeline
+	var dedup mongo.Pipeline
 	switch schemaType {
 	case "Section":
-		// No extra middle stages
+		// No extra stages
 
 	case "Professor":
 		// Lookup the list of professors from the list of sections
-		lookupProf = mongo.Pipeline{
+		lookup = append(lookup,
 			bson.D{{Key: "$lookup", Value: bson.D{
 				{Key: "from", Value: "professors"},
 				{Key: "localField", Value: "sections.professors"},
 				{Key: "foreignField", Value: "_id"},
 				{Key: "as", Value: "professors"},
-			}}},
-		}
+			}}})
 
 		// Remove the duplicate professors
 		dedup = mongo.Pipeline{
@@ -316,25 +312,24 @@ func buildCoursePipeline(schemaType string, courseQuery bson.M, paginateMap map[
 	}
 
 	extract := mongo.Pipeline{
-		// Unwind the target object
+		// Unwind the target objects
 		bson.D{{Key: "$unwind", Value: bson.D{
-			{Key: "path", Value: "$" + typeToField[schemaType]},
+			{Key: "path", Value: "$" + field},
 			{Key: "preserveNullAndEmptyArrays", Value: false},
 		}}},
 
 		// Replace the courses with the target objects
-		bson.D{{Key: "$replaceWith", Value: "$" + typeToField[schemaType]}},
+		bson.D{{Key: "$replaceWith", Value: "$" + field}},
 	}
 
 	paginate := mongo.Pipeline{
-		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
-
+		bson.D{{Key: "$sort", Value: getSort(schemaType)}},
 		paginateMap["latter_offset"],
 		paginateMap["limit"],
 	}
 
-	pipeline := lookupSection
-	pipeline = append(pipeline, lookupProf...)
+	pipeline := filterCourse
+	pipeline = append(pipeline, lookup...)
 	pipeline = append(pipeline, extract...)
 	pipeline = append(pipeline, dedup...)
 	pipeline = append(pipeline, paginate...)

--- a/rest/controllers/course.go
+++ b/rest/controllers/course.go
@@ -3,8 +3,9 @@ package controllers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/UTDNebula/nebula-api/rest/configs"
@@ -15,6 +16,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 var courseCollection *mongo.Collection = configs.GetCollection("courses")
@@ -52,14 +54,21 @@ func CourseSearch(c *gin.Context) {
 		return
 	}
 
-	optionLimit, err := configs.GetOptionLimit(&query, c)
+	offset, limit, err := configs.GetLimit(&query, c)
 	if err != nil {
 		respond(c, http.StatusBadRequest, "offset is not type integer", err.Error())
 		return
 	}
+	opts := options.Find().
+		SetSort(bson.D{
+			{Key: "subject_prefix", Value: 1},
+			{Key: "course_number", Value: 1},
+			{Key: "catalog_year", Value: 1},
+		}).
+		SetSkip(offset).SetLimit(limit)
 
 	// Get cursor for query results
-	cursor, err := courseCollection.Find(ctx, query, optionLimit)
+	cursor, err := courseCollection.Find(ctx, query, opts)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return
@@ -218,7 +227,7 @@ func CourseProfessorById(c *gin.Context) {
 	courseAggregate[schema.Professor]("ById", c)
 }
 
-// courseAggregate is a generic function that gets a specified field of the courses, filters depending on the flag
+// courseAggregate returns the list of aggregated objects from list of filtered courses
 func courseAggregate[T any](flag string, c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 	defer cancel()
@@ -233,28 +242,15 @@ func courseAggregate[T any](flag string, c *gin.Context) {
 	}
 
 	// Determine the offset and limit for pagination & delete offset fields
-	paginate, err := configs.GetAggregateLimit(&courseQuery, c)
+	paginateMap, err := configs.GetAggregateLimit(&courseQuery, c)
 	if err != nil {
 		respond(c, http.StatusBadRequest, "Error offset is not type integer", err.Error())
 		return
 	}
 
-	// Determine the endpoint based on the type of the desired query results
-
-	var zero T
-	var endpoint string
-	switch any(zero).(type) {
-	case schema.Section:
-		endpoint = "sections"
-	case schema.Professor:
-		endpoint = "professors"
-	default:
-		respondWithInternalError(c, fmt.Errorf("invalid schema type for courseAggregate"))
-		return
-	}
-
 	// Pipeline to query the field from the filtered courses
-	courseQueryPipeline := buildCoursePipeline(endpoint, courseQuery, paginate)
+	schemaType := strings.Split(reflect.TypeFor[[]T]().String(), ".")[1]
+	courseQueryPipeline := buildCoursePipeline(schemaType, courseQuery, paginateMap)
 
 	// perform aggregation on the pipeline
 	cursor, err := courseCollection.Aggregate(ctx, courseQueryPipeline)
@@ -272,14 +268,13 @@ func courseAggregate[T any](flag string, c *gin.Context) {
 	respond(c, http.StatusOK, "success", queryResults)
 }
 
-// buildCoursePipeline builds the pipeline to aggregate the list of specified objects from list of courses
-func buildCoursePipeline(endpoint string, courseQuery bson.M, paginate map[string]bson.D) mongo.Pipeline {
-	baseStages := mongo.Pipeline{
+// buildCoursePipeline builds the pipeline to aggregate the list of object from list of courses
+func buildCoursePipeline(schemaType string, courseQuery bson.M, paginateMap map[string]bson.D) mongo.Pipeline {
+	lookupSection := mongo.Pipeline{
 		bson.D{{Key: "$match", Value: courseQuery}},
 
-		// Skip to the offset, then limit to the number of courses
-		paginate["former_offset"],
-		paginate["limit"],
+		paginateMap["former_offset"],
+		paginateMap["limit"],
 
 		// Lookup the list of sections from the courses
 		bson.D{{Key: "$lookup", Value: bson.D{
@@ -290,14 +285,14 @@ func buildCoursePipeline(endpoint string, courseQuery bson.M, paginate map[strin
 		}}},
 	}
 
-	var lookupStages, dedupStages mongo.Pipeline
-	switch endpoint {
-	case "sections":
-		// No extra stages middle stages
+	var lookupProf, dedup mongo.Pipeline
+	switch schemaType {
+	case "Section":
+		// No extra middle stages
 
-	case "professors":
+	case "Professor":
 		// Lookup the list of professors from the list of sections
-		lookupStages = mongo.Pipeline{
+		lookupProf = mongo.Pipeline{
 			bson.D{{Key: "$lookup", Value: bson.D{
 				{Key: "from", Value: "professors"},
 				{Key: "localField", Value: "sections.professors"},
@@ -307,7 +302,7 @@ func buildCoursePipeline(endpoint string, courseQuery bson.M, paginate map[strin
 		}
 
 		// Remove the duplicate professors
-		dedupStages = mongo.Pipeline{
+		dedup = mongo.Pipeline{
 			bson.D{{Key: "$group", Value: bson.D{
 				{Key: "_id", Value: "$_id"},
 				{Key: "professors", Value: bson.D{{Key: "$first", Value: "$$ROOT"}}},
@@ -317,28 +312,31 @@ func buildCoursePipeline(endpoint string, courseQuery bson.M, paginate map[strin
 		}
 
 	default:
-		panic("invalid endpoint for coursePipeline: " + endpoint)
+		panic("invalid schema for coursePipeline: " + schemaType)
 	}
 
-	replaceStages := mongo.Pipeline{
-		// Unwind the target object of the sections
+	extract := mongo.Pipeline{
+		// Unwind the target object
 		bson.D{{Key: "$unwind", Value: bson.D{
-			{Key: "path", Value: "$" + endpoint},
+			{Key: "path", Value: "$" + typeToField[schemaType]},
 			{Key: "preserveNullAndEmptyArrays", Value: false},
 		}}},
 
 		// Replace the courses with the target objects
-		bson.D{{Key: "$replaceWith", Value: "$" + endpoint}},
+		bson.D{{Key: "$replaceWith", Value: "$" + typeToField[schemaType]}},
 	}
 
-	middleStages := append(append(lookupStages, replaceStages...), dedupStages...)
-
-	paginateStages := mongo.Pipeline{
+	paginate := mongo.Pipeline{
 		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
 
-		paginate["latter_offset"],
-		paginate["limit"],
+		paginateMap["latter_offset"],
+		paginateMap["limit"],
 	}
 
-	return append(append(baseStages, middleStages...), paginateStages...)
+	pipeline := lookupSection
+	pipeline = append(pipeline, lookupProf...)
+	pipeline = append(pipeline, extract...)
+	pipeline = append(pipeline, dedup...)
+	pipeline = append(pipeline, paginate...)
+	return pipeline
 }

--- a/rest/controllers/professor.go
+++ b/rest/controllers/professor.go
@@ -20,10 +20,6 @@ import (
 )
 
 var professorCollection *mongo.Collection = configs.GetCollection("professors")
-var aggregateMap = map[string]string{
-	"Course":  "courses",
-	"Section": "sections",
-}
 
 // @Id				professorSearch
 // @Router			/professor [get]
@@ -272,9 +268,8 @@ func professorAggregate[T any](flag string, c *gin.Context) {
 	}
 
 	// Pipeline to query the courses or sections from the filtered professors (or a single professor)
-	endpointType := strings.Split(reflect.TypeOf(profAggregate).String(), ".")[1]
-	endpoint := aggregateMap[endpointType]
-	profPipeline := buildProfessorPipeline(endpoint, profQuery, paginate)
+	schemaType := strings.Split(reflect.TypeFor[[]T]().String(), ".")[1]
+	profPipeline := buildProfessorPipeline(schemaType, profQuery, paginate)
 
 	// Perform aggreration on the pipeline
 	cursor, err := professorCollection.Aggregate(ctx, profPipeline)
@@ -284,7 +279,7 @@ func professorAggregate[T any](flag string, c *gin.Context) {
 		return
 	}
 
-	// Parse the array of courses or sections from these professors
+	// Parse the array of objects from these professors
 	if err = cursor.All(ctx, &profAggregate); err != nil {
 		respondWithInternalError(c, err)
 		return
@@ -294,17 +289,19 @@ func professorAggregate[T any](flag string, c *gin.Context) {
 }
 
 // Pipeline builder for professor aggregate endpoints
-func buildProfessorPipeline(endpoint string, professorQuery bson.M, paginate map[string]bson.D) mongo.Pipeline {
-	// common stages
-	baseStages := mongo.Pipeline{
-		// filter the professors
+func buildProfessorPipeline(schemaType string, professorQuery bson.M, paginateMap map[string]bson.D) mongo.Pipeline {
+	field := typeToField[schemaType]
+
+	filterProf := mongo.Pipeline{
 		bson.D{{Key: "$match", Value: professorQuery}},
 
-		// paginate the professors before pulling the courses/sections from those professor
-		paginate["former_offset"],
-		paginate["limit"],
+		bson.D{{Key: "$sort", Value: getSort("Professor")}},
+		paginateMap["former_offset"],
+		paginateMap["limit"],
+	}
 
-		// lookup the array of sections from sections collection
+	var lookup = mongo.Pipeline{
+		// Lookup the array of sections from professors
 		bson.D{{Key: "$lookup", Value: bson.D{
 			{Key: "from", Value: "sections"},
 			{Key: "localField", Value: "sections"},
@@ -312,52 +309,43 @@ func buildProfessorPipeline(endpoint string, professorQuery bson.M, paginate map
 			{Key: "as", Value: "sections"},
 		}}},
 	}
-
-	var middleStages mongo.Pipeline
-
-	switch endpoint {
-	case "courses":
-		middleStages = mongo.Pipeline{
-			// project the courses referenced by each section in the array
-			bson.D{{Key: "$project", Value: bson.D{{Key: "courses", Value: "$sections.course_reference"}}}},
-
-			// lookup the array of courses from coures collection
+	switch schemaType {
+	case "Course":
+		lookup = append(lookup,
+			// Lookup the array of courses from array of sections
 			bson.D{{Key: "$lookup", Value: bson.D{
 				{Key: "from", Value: "courses"},
-				{Key: "localField", Value: "courses"},
+				{Key: "localField", Value: "sections.course_reference"},
 				{Key: "foreignField", Value: "_id"},
 				{Key: "as", Value: "courses"},
 			}}},
-		}
+		)
 
-	case "sections":
-		middleStages = mongo.Pipeline{
-			// project the sections
-			bson.D{{Key: "$project", Value: bson.D{{Key: "sections", Value: "$sections"}}}},
-		}
+	case "Section":
+		// No extra stages
 
 	default:
-		panic("invalid endpoint for professorPipeline: " + endpoint)
+		panic("invalid schema for professorPipeline: " + schemaType)
 	}
 
-	// common pagination stages
-	paginateStages := mongo.Pipeline{
-		// unwind the courses/sections
+	extract := mongo.Pipeline{
 		bson.D{{Key: "$unwind", Value: bson.D{
-			{Key: "path", Value: "$" + endpoint},
+			{Key: "path", Value: "$" + field},
 			{Key: "preserveNullAndEmptyArrays", Value: false},
 		}}},
 
-		// replace the combination of ids and courses/sections with the courses/sections entirely
-		bson.D{{Key: "$replaceWith", Value: "$" + endpoint}},
-
-		// keep order deterministic between calls
-		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
-
-		// paginate the courses/sections
-		paginate["latter_offset"],
-		paginate["limit"],
+		bson.D{{Key: "$replaceWith", Value: "$" + field}},
 	}
 
-	return append(append(baseStages, middleStages...), paginateStages...)
+	paginate := mongo.Pipeline{
+		bson.D{{Key: "$sort", Value: getSort(schemaType)}},
+		paginateMap["latter_offset"],
+		paginateMap["limit"],
+	}
+
+	pipeline := filterProf
+	pipeline = append(pipeline, lookup...)
+	pipeline = append(pipeline, extract...)
+	pipeline = append(pipeline, paginate...)
+	return pipeline
 }

--- a/rest/controllers/professor.go
+++ b/rest/controllers/professor.go
@@ -16,6 +16,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 var professorCollection *mongo.Collection = configs.GetCollection("professors")
@@ -67,14 +68,15 @@ func ProfessorSearch(c *gin.Context) {
 		return
 	}
 
-	optionLimit, err := configs.GetOptionLimit(&query, c)
+	offset, limit, err := configs.GetLimit(&query, c)
 	if err != nil {
 		respond(c, http.StatusBadRequest, "offset is not type integer", err.Error())
 		return
 	}
+	opts := options.Find().SetSkip(offset).SetLimit(limit)
 
 	// get cursor for query results
-	cursor, err := professorCollection.Find(ctx, query, optionLimit)
+	cursor, err := professorCollection.Find(ctx, query, opts)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return

--- a/rest/controllers/section.go
+++ b/rest/controllers/section.go
@@ -14,6 +14,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 var sectionCollection *mongo.Collection = configs.GetCollection("sections")
@@ -61,14 +62,15 @@ func SectionSearch(c *gin.Context) {
 		return
 	}
 
-	optionLimit, err := configs.GetOptionLimit(&query, c)
+	offset, limit, err := configs.GetLimit(&query, c)
 	if err != nil {
 		respond(c, http.StatusBadRequest, "offset is not type integer", err.Error())
 		return
 	}
+	opts := options.Find().SetSkip(offset).SetLimit(limit)
 
 	// get cursor for query results
-	cursor, err := sectionCollection.Find(ctx, query, optionLimit)
+	cursor, err := sectionCollection.Find(ctx, query, opts)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return

--- a/rest/controllers/section.go
+++ b/rest/controllers/section.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/UTDNebula/nebula-api/rest/configs"
@@ -154,7 +156,7 @@ func SectionById(c *gin.Context) {
 // @Failure		500								{object}	schema.APIResponse[string]			"A string describing the error"
 // @Failure		400								{object}	schema.APIResponse[string]			"A string describing the error"
 func SectionCourseSearch(c *gin.Context) {
-	sectionCourse("Search", c)
+	sectionAggregate[schema.Course]("Search", c)
 }
 
 // @Id				sectionCourseById
@@ -167,43 +169,7 @@ func SectionCourseSearch(c *gin.Context) {
 // @Failure		500	{object}	schema.APIResponse[string]			"A string describing the error"
 // @Failure		400	{object}	schema.APIResponse[string]			"A string describing the error"
 func SectionCourseById(c *gin.Context) {
-	sectionCourse("ById", c)
-}
-
-// Get an array of courses from sections, filtered based on the the flag
-func sectionCourse(flag string, c *gin.Context) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
-	defer cancel()
-
-	var sectionCourses []schema.Course
-	var sectionQuery bson.M
-	var err error
-	if sectionQuery, err = getQuery[schema.Section](flag, c); err != nil {
-		return
-	}
-
-	paginate, err := configs.GetAggregateLimit(&sectionQuery, c)
-	if err != nil {
-		respond(c, http.StatusBadRequest, "Error offset is not type integer", err.Error())
-		return
-	}
-
-	cursor, err := sectionCollection.Aggregate(ctx, buildSectionPipeline("courses", sectionQuery, paginate))
-	if err != nil {
-		respondWithInternalError(c, err)
-		return
-	}
-	if err = cursor.All(ctx, &sectionCourses); err != nil {
-		respondWithInternalError(c, err)
-		return
-	}
-
-	switch flag {
-	case "Search":
-		respond(c, http.StatusOK, "success", sectionCourses)
-	case "ById":
-		respond(c, http.StatusOK, "success", sectionCourses[0])
-	}
+	sectionAggregate[schema.Course]("ById", c)
 }
 
 // @Id				sectionProfessorSearch
@@ -238,7 +204,7 @@ func sectionCourse(flag string, c *gin.Context) {
 // @Failure		500								{object}	schema.APIResponse[string]				"A string describing the error"
 // @Failure		400								{object}	schema.APIResponse[string]				"A string describing the error"
 func SectionProfessorSearch(c *gin.Context) {
-	sectionProfessor("Search", c)
+	sectionAggregate[schema.Professor]("Search", c)
 }
 
 // @Id				sectionProfessorById
@@ -251,110 +217,93 @@ func SectionProfessorSearch(c *gin.Context) {
 // @Failure		500	{object}	schema.APIResponse[string]				"A string describing the error"
 // @Failure		400	{object}	schema.APIResponse[string]				"A string describing the error"
 func SectionProfessorById(c *gin.Context) {
-	sectionProfessor("ById", c)
+	sectionAggregate[schema.Professor]("ById", c)
 }
 
-// Get an array of professors from sections,
-func sectionProfessor(flag string, c *gin.Context) {
+// sectionAggregate returns the list of aggregated objects from list of filtered sections
+func sectionAggregate[T any](flag string, c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 	defer cancel()
 
-	var sectionProfessors []schema.Professor
+	var queryResults []T
 	var sectionQuery bson.M
+
+	// Determine the section query
 	sectionQuery, err := getQuery[schema.Section](flag, c)
 	if err != nil {
 		return
 	}
 
-	paginate, err := configs.GetAggregateLimit(&sectionQuery, c)
+	// Determine the offset and limit for pagination & delete offset fields
+	paginateMap, err := configs.GetAggregateLimit(&sectionQuery, c)
 	if err != nil {
 		respond(c, http.StatusBadRequest, "Error offset is not type integer", err.Error())
 		return
 	}
 
-	cursor, err := sectionCollection.Aggregate(ctx, buildSectionPipeline("professors", sectionQuery, paginate))
+	// Pipeline to query the field from the filtered sections
+	schemaType := strings.Split(reflect.TypeFor[[]T]().String(), ".")[1]
+	sectionQueryPipeline := buildSectionPipeline(schemaType, sectionQuery, paginateMap)
+
+	// perform aggregation on the pipeline
+	cursor, err := sectionCollection.Aggregate(ctx, sectionQueryPipeline)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return
 	}
-	if err = cursor.All(ctx, &sectionProfessors); err != nil {
+	defer cursor.Close(ctx)
+
+	if err = cursor.All(ctx, &queryResults); err != nil {
 		respondWithInternalError(c, err)
 		return
 	}
 
-	respond(c, http.StatusOK, "success", sectionProfessors)
+	respond(c, http.StatusOK, "success", queryResults)
 }
 
-// buildSectionPipeline builds the pipeline to aggregate courses or professors from filtered sections
-func buildSectionPipeline(endpoint string, sectionQuery bson.M, paginate map[string]bson.D) mongo.Pipeline {
-	baseStages := mongo.Pipeline{
-		// filter the sections
+// buildSectionPipeline builds the pipeline to aggregate targets from filtered sections
+func buildSectionPipeline(schemaType string, sectionQuery bson.M, paginateMap map[string]bson.D) mongo.Pipeline {
+	field := typeToField[schemaType]
+
+	filterSection := mongo.Pipeline{
 		bson.D{{Key: "$match", Value: sectionQuery}},
 
-		// paginate the sections before pulling courses from those sections
-		paginate["former_offset"],
-		paginate["limit"],
+		bson.D{{Key: "$sort", Value: getSort("Section")}},
+		paginateMap["former_offset"],
+		paginateMap["limit"],
 	}
 
-	var lookupStages mongo.Pipeline
-	switch endpoint {
-	case "courses":
-		lookupStages = mongo.Pipeline{
-			// lookup the course referenced by sections from the course collection
-			bson.D{{Key: "$lookup", Value: bson.D{
-				{Key: "from", Value: "courses"},
-				{Key: "localField", Value: "course_reference"},
-				{Key: "foreignField", Value: "_id"},
-				{Key: "as", Value: "courses"},
-			}}},
-		}
-
-	case "professors":
-		lookupStages = mongo.Pipeline{
-			// lookup the professors referenced by sections from the course collection
-			bson.D{{Key: "$lookup", Value: bson.D{
-				{Key: "from", Value: "professors"},
-				{Key: "localField", Value: "professors"},
-				{Key: "foreignField", Value: "_id"},
-				{Key: "as", Value: "professors"},
-			}}},
-		}
-
-	default:
-		panic("invalid endpoint for buildSectionPipeline: " + endpoint)
-	}
-
-	replaceStages := mongo.Pipeline{
-		// project to remove every other fields except for courses/professors
-		bson.D{{Key: "$project", Value: bson.D{
-			{Key: endpoint, Value: "$" + endpoint},
+	var lookup = mongo.Pipeline{
+		// Lookup the target objects from sections
+		bson.D{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: field},
+			{Key: "localField", Value: field},
+			{Key: "foreignField", Value: "_id"},
+			{Key: "as", Value: field},
 		}}},
+	}
 
-		// unwind the courses/professors
+	extract := mongo.Pipeline{
+		// Unwind the target objects
 		bson.D{{Key: "$unwind", Value: bson.D{
-			{Key: "path", Value: "$" + endpoint},
+			{Key: "path", Value: "$" + field},
 			{Key: "preserveNullAndEmptyArrays", Value: false},
 		}}},
 
-		// replace the combinations of id and course/professor with courses/professors entirely
-		bson.D{{Key: "$replaceWith", Value: "$" + endpoint}},
-
-		// remove duplicate courses/professors
-		bson.D{{Key: "$group", Value: bson.D{
-			{Key: "_id", Value: "$_id"},
-			{Key: "item", Value: bson.D{{Key: "$first", Value: "$$ROOT"}}},
-		}}},
-		bson.D{{Key: "$replaceWith", Value: "$item"}},
+		// Replace the sections with the target objects
+		bson.D{{Key: "$replaceWith", Value: "$" + field}},
 	}
 
-	paginateStages := mongo.Pipeline{
-		// keep order deterministic between calls
-		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
+	paginate := mongo.Pipeline{
+		bson.D{{Key: "$sort", Value: getSort(schemaType)}},
 
-		// paginate the courses/professors
-		paginate["latter_offset"],
-		paginate["limit"],
+		paginateMap["latter_offset"],
+		paginateMap["limit"],
 	}
 
-	return append(append(append(baseStages, lookupStages...), replaceStages...), paginateStages...)
+	pipeline := filterSection
+	pipeline = append(pipeline, lookup...)
+	pipeline = append(pipeline, extract...)
+	pipeline = append(pipeline, paginate...)
+	return pipeline
 }

--- a/rest/schema/filter.go
+++ b/rest/schema/filter.go
@@ -19,7 +19,9 @@ var (
 		reflect.TypeFor[primitive.ObjectID](): true,
 	}
 	ignoredParameters = map[string]bool{
-		"offset": true,
+		"former_offset": true,
+		"latter_offset": true,
+		"offset":        true,
 	}
 )
 


### PR DESCRIPTION
# Overview

Linked to https://github.com/UTDNebula/api-tools/pull/185

- Use `SetSort()` to sort the courses by the combo of `subject_prefix`, `course_number`, and `catalog_year`, which has been indexed in MongoDB, so it should return sorted courses in the response despite the courses not being sorted in storage. Due to the indexes, common query such as `subject_prefix=&course_number=` is still efficient. Latency for other queries increases by < 15ms.

- Rewrite `getOptionLimit()` -> `getLimit()` (and unit tests) so it returns only the limit and offset. The options constructing is moved to the controllers because we need to add `SetSort()` to options.

- Rewrite the aggregation pipelines. This is the final rewrite I promise, primarily just the code reformat. Functionality remains (i.e `professor/courses` -> sort and paginate professor, then aggregate to courses, then sort and paginate professor. That way results are always deterministic).

- Add `sectionAggregate()`

I am aware most of the changes are just reformat and hard to track. Probably best to review them on branch `sort-courses`